### PR TITLE
Add About button with git version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ yarn-error.*
 .worktrees/
 
 # generated version file
-src/generated_version.ts
+lib/generated_version.ts

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+
+# worktrees
+.worktrees/
+
+# generated version file
+src/generated_version.ts

--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,9 @@ import {
   Switch,
   TextInput,
   AppState,
+  Modal,
+  Linking,
+  Pressable,
 } from "react-native";
 import * as Location from "expo-location";
 import * as TaskManager from "expo-task-manager";
@@ -23,6 +26,7 @@ import type {
 import { buildHealthData, type HealthData, type HealthQueryResults } from "./lib/health";
 import { pruneThreshold } from "./lib/location";
 import { buildSummary, formatNumber } from "./lib/summary";
+import { getBuildInfo, formatBuildTimestamp } from "./lib/version";
 
 // --- Constants ---
 
@@ -202,6 +206,89 @@ function MetricCard({ label, value, sublabel, fullWidth }: MetricCardProps) {
   );
 }
 
+// --- About Modal ---
+
+function AboutModal({
+  visible,
+  onClose,
+}: {
+  visible: boolean;
+  onClose: () => void;
+}) {
+  const buildInfo = getBuildInfo();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalContainer}>
+        <View style={styles.modalHeader}>
+          <Text style={styles.modalTitle}>About</Text>
+          <TouchableOpacity onPress={onClose} style={styles.modalCloseButton}>
+            <Text style={styles.modalCloseText}>Done</Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView style={styles.modalContent}>
+          <View style={styles.aboutCard}>
+            <Text style={styles.aboutAppName}>Context Grabber</Text>
+            <Text style={styles.aboutTagline}>
+              Export HealthKit, GPS & location data for AI life coaching
+            </Text>
+          </View>
+
+          <View style={styles.aboutCard}>
+            <Text style={styles.metricLabel}>Build Info</Text>
+
+            <View style={styles.aboutRow}>
+              <Text style={styles.aboutRowLabel}>Version</Text>
+              <Text style={styles.aboutRowValue}>
+                {buildInfo.shortSha} ({buildInfo.branch})
+              </Text>
+            </View>
+
+            {buildInfo.timestamp ? (
+              <View style={styles.aboutRow}>
+                <Text style={styles.aboutRowLabel}>Built</Text>
+                <Text style={styles.aboutRowValue}>
+                  {formatBuildTimestamp(buildInfo.timestamp)}
+                </Text>
+              </View>
+            ) : null}
+
+            {buildInfo.commitUrl ? (
+              <TouchableOpacity
+                style={styles.aboutRow}
+                onPress={() => Linking.openURL(buildInfo.commitUrl)}
+              >
+                <Text style={styles.aboutRowLabel}>Commit</Text>
+                <Text style={[styles.aboutRowValue, styles.aboutLink]}>
+                  View on GitHub
+                </Text>
+              </TouchableOpacity>
+            ) : null}
+
+            {buildInfo.repoUrl ? (
+              <TouchableOpacity
+                style={styles.aboutRow}
+                onPress={() => Linking.openURL(buildInfo.repoUrl)}
+              >
+                <Text style={styles.aboutRowLabel}>Repository</Text>
+                <Text style={[styles.aboutRowValue, styles.aboutLink]}>
+                  View on GitHub
+                </Text>
+              </TouchableOpacity>
+            ) : null}
+          </View>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
 // --- App Component ---
 
 export default function App() {
@@ -212,6 +299,7 @@ export default function App() {
   const [retentionDays, setRetentionDays] = useState("30");
   const [locationCount, setLocationCount] = useState(0);
   const [db, setDb] = useState<SQLite.SQLiteDatabase | null>(null);
+  const [aboutVisible, setAboutVisible] = useState(false);
 
   // Initialize database on mount
   useEffect(() => {
@@ -530,11 +618,27 @@ export default function App() {
     <View style={styles.container}>
       <StatusBar style="light" />
       <View style={styles.header}>
-        <Text style={styles.title}>Context Grabber</Text>
-        <Text style={styles.subtitle}>
-          Grab your iPhone context for your AI life coach
-        </Text>
+        <View style={styles.headerRow}>
+          <View style={styles.headerText}>
+            <Text style={styles.title}>Context Grabber</Text>
+            <Text style={styles.subtitle}>
+              Grab your iPhone context for your AI life coach
+            </Text>
+          </View>
+          <TouchableOpacity
+            style={styles.aboutButton}
+            onPress={() => setAboutVisible(true)}
+            accessibilityLabel="About"
+          >
+            <Text style={styles.aboutButtonText}>i</Text>
+          </TouchableOpacity>
+        </View>
       </View>
+
+      <AboutModal
+        visible={aboutVisible}
+        onClose={() => setAboutVisible(false)}
+      />
 
       <ScrollView
         style={styles.content}
@@ -793,5 +897,94 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 16,
     fontWeight: "600",
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+  headerText: {
+    flex: 1,
+  },
+  aboutButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: "#16213e",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 4,
+  },
+  aboutButtonText: {
+    color: "#4cc9f0",
+    fontSize: 16,
+    fontWeight: "700",
+    fontStyle: "italic",
+  },
+  modalContainer: {
+    flex: 1,
+    backgroundColor: "#1a1a2e",
+  },
+  modalHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingTop: Platform.OS === "ios" ? 16 : 20,
+    paddingHorizontal: 20,
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#16213e",
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    color: "#e0e0e0",
+  },
+  modalCloseButton: {
+    padding: 4,
+  },
+  modalCloseText: {
+    color: "#4361ee",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  modalContent: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  aboutCard: {
+    backgroundColor: "#16213e",
+    borderRadius: 12,
+    padding: 16,
+    marginTop: 16,
+  },
+  aboutAppName: {
+    fontSize: 22,
+    fontWeight: "bold",
+    color: "#e0e0e0",
+    marginBottom: 4,
+  },
+  aboutTagline: {
+    fontSize: 14,
+    color: "#888",
+  },
+  aboutRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: "#1a1a2e",
+  },
+  aboutRowLabel: {
+    fontSize: 14,
+    color: "#888",
+  },
+  aboutRowValue: {
+    fontSize: 14,
+    color: "#e0e0e0",
+  },
+  aboutLink: {
+    color: "#4361ee",
   },
 });

--- a/__tests__/version.test.ts
+++ b/__tests__/version.test.ts
@@ -1,0 +1,39 @@
+import { getBuildInfo, formatBuildTimestamp } from "../lib/version";
+
+jest.mock("../lib/generated_version", () => ({
+  GIT_SHA: "abc1234def5678901234567890abcdef12345678",
+  GIT_COMMIT_URL: "https://github.com/test/repo/commit/abc1234",
+  GIT_CURRENT_URL: "https://github.com/test/repo/tree/main",
+  GIT_BRANCH: "main",
+  BUILD_TIMESTAMP: "2025-01-15T10:30:00Z",
+}));
+
+describe("getBuildInfo", () => {
+  it("returns full build info", () => {
+    const info = getBuildInfo();
+    expect(info.sha).toBe("abc1234def5678901234567890abcdef12345678");
+    expect(info.shortSha).toBe("abc1234");
+    expect(info.branch).toBe("main");
+    expect(info.timestamp).toBe("2025-01-15T10:30:00Z");
+    expect(info.commitUrl).toBe(
+      "https://github.com/test/repo/commit/abc1234"
+    );
+    expect(info.repoUrl).toBe("https://github.com/test/repo/tree/main");
+  });
+});
+
+describe("formatBuildTimestamp", () => {
+  it("formats valid ISO timestamp", () => {
+    const result = formatBuildTimestamp("2025-01-15T10:30:00Z");
+    expect(result).toBeTruthy();
+    expect(result).not.toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(formatBuildTimestamp("")).toBe("");
+  });
+
+  it("returns original string for invalid date", () => {
+    expect(formatBuildTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/justfile
+++ b/justfile
@@ -1,7 +1,11 @@
 # Context Grabber task runner
 
+# Generate version info from git
+generate-version:
+    node scripts/generate-version.js
+
 # Deploy OTA update to production
-ota message="OTA update":
+ota message="OTA update": generate-version
     CI=1 npx eas-cli update --branch production --message "{{message}}" --environment production
 
 # Run tests
@@ -9,11 +13,11 @@ test:
     npx jest
 
 # Build and deploy to physical iPhone
-build device="Igor iPhone 17":
+build device="Igor iPhone 17": generate-version
     npx expo run:ios --device "{{device}}"
 
 # Start Metro dev server
-dev:
+dev: generate-version
     npx expo start --dev-client
 
 # Install dependencies and pods

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,0 +1,34 @@
+import {
+  GIT_SHA,
+  GIT_COMMIT_URL,
+  GIT_CURRENT_URL,
+  GIT_BRANCH,
+  BUILD_TIMESTAMP,
+} from "./generated_version";
+
+export type BuildInfo = {
+  sha: string;
+  shortSha: string;
+  branch: string;
+  timestamp: string;
+  commitUrl: string;
+  repoUrl: string;
+};
+
+export function getBuildInfo(): BuildInfo {
+  return {
+    sha: GIT_SHA,
+    shortSha: GIT_SHA.slice(0, 7),
+    branch: GIT_BRANCH,
+    timestamp: BUILD_TIMESTAMP,
+    commitUrl: GIT_COMMIT_URL,
+    repoUrl: GIT_CURRENT_URL,
+  };
+}
+
+export function formatBuildTimestamp(timestamp: string): string {
+  if (!timestamp) return "";
+  const date = new Date(timestamp);
+  if (isNaN(date.getTime())) return timestamp;
+  return date.toLocaleString();
+}

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const { writeFileSync } = require("fs");
+
+const sha = execSync("git rev-parse HEAD").toString().trim();
+const branch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
+const repoUrl = execSync("git remote get-url origin")
+	.toString()
+	.trim()
+	.replace(/\.git$/, "")
+	.replace(/git@github\.com:/, "https://github.com/");
+const buildTime = new Date().toISOString();
+
+const content = `// Auto-generated at build time - DO NOT EDIT
+export const GIT_SHA = "${sha}";
+export const GIT_COMMIT_URL = "${repoUrl}/commit/${sha}";
+export const GIT_CURRENT_URL = "${repoUrl}/tree/${branch}";
+export const GIT_BRANCH = "${branch}";
+export const BUILD_TIMESTAMP = "${buildTime}";
+`;
+
+writeFileSync("lib/generated_version.ts", content);
+console.log("Generated lib/generated_version.ts");


### PR DESCRIPTION
## Summary
- Add info button in header that opens an About modal showing build version (git SHA, branch, timestamp) with tappable GitHub links
- Add build-time version generation script (`scripts/generate-version.js`) that captures git info into `lib/generated_version.ts`
- Wire version generation into justfile `dev`, `build`, and `ota` recipes as a dependency

## Test plan
- [ ] Verify `just generate-version` produces `lib/generated_version.ts` with correct git info
- [ ] Tap "i" button in header → About modal slides up with build info
- [ ] Tap "View on GitHub" links → opens correct URLs in browser
- [ ] Tap "Done" → modal closes
- [ ] `npm test` passes (new version tests + existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an About modal accessible from the main header, displaying build information including version, branch, build timestamp, and links to the associated commit and repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->