### PR TITLE
Add 7-day metric detail view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -575,9 +575,11 @@ export default function App() {
         return aggregateHeartRate(mapped, now);
       }
       case "sleep": {
+        // Query 8 days back to capture overnight sessions starting before the 7-day window
+        const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
         const samples = await HealthKit.queryCategorySamples(CTI.sleep, {
           limit: 0,
-          filter: dateFilter,
+          filter: { date: { startDate: eightDaysAgo, endDate: now } },
         });
         return aggregateSleep([...samples], now);
       }

--- a/App.tsx
+++ b/App.tsx
@@ -27,6 +27,16 @@ import { buildHealthData, type HealthData, type HealthQueryResults } from "./lib
 import { pruneThreshold } from "./lib/location";
 import { buildSummary, formatNumber } from "./lib/summary";
 import { getBuildInfo, formatBuildTimestamp } from "./lib/version";
+import {
+  type MetricKey,
+  type DailyValue,
+  type HeartRateDaily,
+  aggregateHeartRate,
+  aggregateSleep,
+  aggregateMeditation,
+  pickLatestPerDay,
+} from "./lib/weekly";
+import MetricDetailSheet from "./components/MetricDetailSheet";
 
 // --- Constants ---
 
@@ -187,22 +197,28 @@ TaskManager.defineTask(LOCATION_TASK_NAME, async ({ data, error }) => {
 // --- MetricCard Component ---
 
 type MetricCardProps = {
+  metricKey: MetricKey;
   label: string;
   value: string;
   sublabel: string;
   fullWidth?: boolean;
+  onPress: (key: MetricKey) => void;
 };
 
-function MetricCard({ label, value, sublabel, fullWidth }: MetricCardProps) {
+function MetricCard({ metricKey, label, value, sublabel, fullWidth, onPress }: MetricCardProps) {
   const isNull = value === "\u2014";
   return (
-    <View style={[styles.metricCard, fullWidth && styles.metricCardFull]}>
+    <TouchableOpacity
+      style={[styles.metricCard, fullWidth && styles.metricCardFull]}
+      onPress={() => onPress(metricKey)}
+      activeOpacity={0.7}
+    >
       <Text style={styles.metricLabel}>{label}</Text>
       <Text style={[styles.metricValue, isNull && styles.metricValueNull]}>
         {value}
       </Text>
       <Text style={styles.metricSublabel}>{sublabel}</Text>
-    </View>
+    </TouchableOpacity>
   );
 }
 
@@ -300,6 +316,10 @@ export default function App() {
   const [locationCount, setLocationCount] = useState(0);
   const [db, setDb] = useState<SQLite.SQLiteDatabase | null>(null);
   const [aboutVisible, setAboutVisible] = useState(false);
+  const [selectedMetric, setSelectedMetric] = useState<MetricKey | null>(null);
+  const [weeklyCache, setWeeklyCache] = useState<Partial<Record<MetricKey, DailyValue[] | HeartRateDaily[]>>>({});
+  const [weeklyLoading, setWeeklyLoading] = useState(false);
+  const [weeklyError, setWeeklyError] = useState<string | null>(null);
 
   // Initialize database on mount
   useEffect(() => {
@@ -507,9 +527,101 @@ export default function App() {
     };
   }
 
+  async function grabWeeklyData(metric: MetricKey): Promise<DailyValue[] | HeartRateDaily[]> {
+    const now = new Date();
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const dateFilter = { date: { startDate: sevenDaysAgo, endDate: now } };
+
+    switch (metric) {
+      case "steps":
+      case "activeEnergy":
+      case "walkingDistance": {
+        const identifier =
+          metric === "steps" ? QTI.stepCount
+          : metric === "activeEnergy" ? QTI.activeEnergy
+          : QTI.distance;
+        const dayPromises = Array.from({ length: 7 }, (_, idx) => {
+          const i = 6 - idx;
+          const dayStart = new Date(now);
+          dayStart.setDate(dayStart.getDate() - i);
+          dayStart.setHours(0, 0, 0, 0);
+          const dayEnd = new Date(dayStart);
+          dayEnd.setHours(23, 59, 59, 999);
+          const dateKey = `${dayStart.getFullYear()}-${String(dayStart.getMonth() + 1).padStart(2, "0")}-${String(dayStart.getDate()).padStart(2, "0")}`;
+          return HealthKit.queryStatisticsForQuantity(
+            identifier,
+            ["cumulativeSum"],
+            { filter: { date: { startDate: dayStart, endDate: dayEnd } } },
+          )
+            .then((result) => ({
+              date: dateKey,
+              value: result?.sumQuantity?.quantity != null
+                ? Math.round(result.sumQuantity.quantity * 100) / 100
+                : null,
+            }))
+            .catch(() => ({ date: dateKey, value: null }));
+        });
+        return Promise.all(dayPromises);
+      }
+      case "heartRate": {
+        const samples = await HealthKit.queryQuantitySamples(QTI.heartRate, {
+          limit: 0,
+          filter: dateFilter,
+        });
+        const mapped = samples.map((s: any) => ({
+          startDate: new Date(s.startDate),
+          quantity: s.quantity,
+        }));
+        return aggregateHeartRate(mapped, now);
+      }
+      case "sleep": {
+        const samples = await HealthKit.queryCategorySamples(CTI.sleep, {
+          limit: 0,
+          filter: dateFilter,
+        });
+        return aggregateSleep([...samples], now);
+      }
+      case "weight": {
+        const samples = await HealthKit.queryQuantitySamples(QTI.bodyMass, {
+          limit: 0,
+          filter: dateFilter,
+        });
+        const mapped = samples.map((s: any) => ({
+          startDate: new Date(s.startDate),
+          quantity: s.quantity,
+        }));
+        return pickLatestPerDay(mapped, now);
+      }
+      case "meditation": {
+        const sessions = await HealthKit.queryCategorySamples(CTI.mindfulSession, {
+          limit: 0,
+          filter: dateFilter,
+        });
+        return aggregateMeditation([...sessions], now);
+      }
+    }
+  }
+
+  async function handleMetricPress(key: MetricKey) {
+    setSelectedMetric(key);
+    setWeeklyError(null);
+    if (weeklyCache[key]) return;
+    setWeeklyLoading(true);
+    try {
+      const data = await grabWeeklyData(key);
+      setWeeklyCache((prev) => ({ ...prev, [key]: data }));
+    } catch (e: any) {
+      setWeeklyError(e.message ?? "Failed to load weekly data");
+    } finally {
+      setWeeklyLoading(false);
+    }
+  }
+
   async function grabContext() {
     setLoading(true);
     setError(null);
+    setWeeklyCache({});
+    setWeeklyError(null);
     try {
       await HealthKit.requestAuthorization({
         toRead: [
@@ -571,45 +683,59 @@ export default function App() {
   const metrics: MetricCardProps[] = snapshot
     ? [
         {
+          metricKey: "steps" as MetricKey,
           label: "Steps",
           value: h?.steps != null ? formatNumber(h.steps) : "\u2014",
           sublabel: "today",
+          onPress: handleMetricPress,
         },
         {
+          metricKey: "heartRate" as MetricKey,
           label: "Heart Rate",
           value: h?.heartRate != null ? `${h.heartRate} bpm` : "\u2014",
           sublabel: "latest",
+          onPress: handleMetricPress,
         },
         {
+          metricKey: "sleep" as MetricKey,
           label: "Sleep",
           value: h?.sleepHours != null ? `${h.sleepHours} hrs` : "\u2014",
           sublabel:
             h?.bedtime && h?.wakeTime
               ? `${h.bedtime} \u2013 ${h.wakeTime}`
               : "last night",
+          onPress: handleMetricPress,
         },
         {
+          metricKey: "activeEnergy" as MetricKey,
           label: "Active Energy",
           value: h?.activeEnergy != null ? `${formatNumber(h.activeEnergy)} kcal` : "\u2014",
           sublabel: "today",
+          onPress: handleMetricPress,
         },
         {
+          metricKey: "walkingDistance" as MetricKey,
           label: "Walking Distance",
           value: h?.walkingDistance != null ? `${h.walkingDistance} km` : "\u2014",
           sublabel: "today",
+          onPress: handleMetricPress,
         },
         {
+          metricKey: "weight" as MetricKey,
           label: "Weight",
           value: h?.weight != null ? `${h.weight} kg` : "\u2014",
           sublabel:
             h?.weightDaysLast7 != null
               ? `${h.weightDaysLast7}/7 days weighed`
               : "latest",
+          onPress: handleMetricPress,
         },
         {
+          metricKey: "meditation" as MetricKey,
           label: "Meditation",
           value: h?.meditationMinutes != null ? `${h.meditationMinutes} min` : "\u2014",
           sublabel: "today",
+          onPress: handleMetricPress,
         },
       ]
     : [];
@@ -690,12 +816,12 @@ export default function App() {
               {metrics.map((m, i) => (
                 <MetricCard
                   key={m.label}
+                  metricKey={m.metricKey}
                   label={m.label}
                   value={m.value}
                   sublabel={m.sublabel}
-                  fullWidth={
-                    metrics.length % 2 === 1 && i === metrics.length - 1
-                  }
+                  fullWidth={metrics.length % 2 === 1 && i === metrics.length - 1}
+                  onPress={handleMetricPress}
                 />
               ))}
             </View>
@@ -745,6 +871,23 @@ export default function App() {
           </TouchableOpacity>
         )}
       </View>
+      {selectedMetric && (
+        <MetricDetailSheet
+          metricKey={selectedMetric}
+          currentValue={
+            metrics.find((m) => m.metricKey === selectedMetric)?.value ?? "\u2014"
+          }
+          currentSublabel={
+            metrics.find((m) => m.metricKey === selectedMetric)?.sublabel ?? ""
+          }
+          data={weeklyCache[selectedMetric] ?? null}
+          error={weeklyError}
+          onClose={() => {
+            setSelectedMetric(null);
+            setWeeklyError(null);
+          }}
+        />
+      )}
     </View>
   );
 }

--- a/__tests__/weekly.test.ts
+++ b/__tests__/weekly.test.ts
@@ -1,0 +1,417 @@
+import {
+  formatDateKey,
+  bucketByDay,
+  computeAverage,
+  aggregateHeartRate,
+  aggregateSleep,
+  aggregateMeditation,
+  pickLatestPerDay,
+  type DailyValue,
+  type HeartRateDaily,
+  type MetricKey,
+} from "../lib/weekly";
+import type { SleepSample, MindfulSession } from "../lib/health";
+
+// Helper: make a Date in LOCAL time (month is 0-indexed)
+// 2026-03-15 local => new Date(2026, 2, 15)
+const D = (y: number, m: number, d: number) => new Date(y, m - 1, d);
+
+// ─── formatDateKey ────────────────────────────────────────────────────────────
+
+describe("formatDateKey", () => {
+  it("formats a date as YYYY-MM-DD in local time", () => {
+    expect(formatDateKey(D(2026, 3, 15))).toBe("2026-03-15");
+  });
+
+  it("zero-pads month and day", () => {
+    expect(formatDateKey(D(2026, 1, 5))).toBe("2026-01-05");
+  });
+
+  it("handles year boundary correctly", () => {
+    expect(formatDateKey(D(2025, 12, 31))).toBe("2025-12-31");
+    expect(formatDateKey(D(2026, 1, 1))).toBe("2026-01-01");
+  });
+});
+
+// ─── bucketByDay ──────────────────────────────────────────────────────────────
+
+type SimpleQuantitySample = { startDate: Date | string; quantity: number };
+
+describe("bucketByDay", () => {
+  const endDate = D(2026, 3, 15); // Sunday
+
+  it("returns 7 null days for empty input", () => {
+    const result = bucketByDay<SimpleQuantitySample>([], endDate, 7, (samples) =>
+      samples.reduce((s, x) => s + x.quantity, 0)
+    );
+    expect(result).toHaveLength(7);
+    expect(result.every((r) => r.value === null)).toBe(true);
+  });
+
+  it("assigns samples to the correct day", () => {
+    // One sample on 2026-03-14 (the day before endDate)
+    const samples: SimpleQuantitySample[] = [
+      { startDate: D(2026, 3, 14), quantity: 42 },
+    ];
+    const result = bucketByDay(samples, endDate, 7, (s) =>
+      s.reduce((acc, x) => acc + x.quantity, 0)
+    );
+    // result[0] = oldest (2026-03-09), result[6] = endDate (2026-03-15)
+    const march14 = result.find((r) => r.date === "2026-03-14");
+    expect(march14).toBeDefined();
+    expect(march14!.value).toBe(42);
+  });
+
+  it("includes the endDate itself as the last bucket", () => {
+    const samples: SimpleQuantitySample[] = [
+      { startDate: D(2026, 3, 15), quantity: 99 },
+    ];
+    const result = bucketByDay(samples, endDate, 7, (s) =>
+      s.reduce((acc, x) => acc + x.quantity, 0)
+    );
+    expect(result[6].date).toBe("2026-03-15");
+    expect(result[6].value).toBe(99);
+  });
+
+  it("ignores samples outside the 7-day window", () => {
+    const samples: SimpleQuantitySample[] = [
+      { startDate: D(2026, 3, 8), quantity: 10 }, // 8 days ago — outside window
+    ];
+    const result = bucketByDay(samples, endDate, 7, (s) =>
+      s.reduce((acc, x) => acc + x.quantity, 0)
+    );
+    expect(result.every((r) => r.value === null)).toBe(true);
+  });
+
+  it("produces a null for a day with no samples (gap)", () => {
+    // Only sample on 2026-03-13
+    const samples: SimpleQuantitySample[] = [
+      { startDate: D(2026, 3, 13), quantity: 5 },
+    ];
+    const result = bucketByDay(samples, endDate, 7, (s) =>
+      s.reduce((acc, x) => acc + x.quantity, 0)
+    );
+    // Days without samples should be null
+    const nullDays = result.filter((r) => r.value === null);
+    expect(nullDays.length).toBe(6);
+  });
+
+  it("aggregates multiple samples falling on the same day", () => {
+    const samples: SimpleQuantitySample[] = [
+      { startDate: D(2026, 3, 14), quantity: 10 },
+      { startDate: D(2026, 3, 14), quantity: 20 },
+    ];
+    const result = bucketByDay(samples, endDate, 7, (s) =>
+      s.reduce((acc, x) => acc + x.quantity, 0)
+    );
+    const march14 = result.find((r) => r.date === "2026-03-14");
+    expect(march14!.value).toBe(30);
+  });
+
+  it("returns dates in chronological order (oldest first)", () => {
+    const result = bucketByDay<SimpleQuantitySample>([], endDate, 7, () => 0);
+    const dates = result.map((r) => r.date);
+    expect(dates[0]).toBe("2026-03-09");
+    expect(dates[6]).toBe("2026-03-15");
+  });
+});
+
+// ─── computeAverage ───────────────────────────────────────────────────────────
+
+describe("computeAverage", () => {
+  it("returns null for an empty array", () => {
+    expect(computeAverage([])).toBeNull();
+  });
+
+  it("returns null when all values are null", () => {
+    const values: DailyValue[] = [
+      { date: "2026-03-09", value: null },
+      { date: "2026-03-10", value: null },
+    ];
+    expect(computeAverage(values)).toBeNull();
+  });
+
+  it("ignores null values in the average", () => {
+    const values: DailyValue[] = [
+      { date: "2026-03-09", value: null },
+      { date: "2026-03-10", value: 10 },
+      { date: "2026-03-11", value: 20 },
+    ];
+    expect(computeAverage(values)).toBe(15);
+  });
+
+  it("rounds to 1 decimal place", () => {
+    // 10 + 10 + 11 = 31, / 3 = 10.333... → 10.3
+    const values: DailyValue[] = [
+      { date: "2026-03-09", value: 10 },
+      { date: "2026-03-10", value: 10 },
+      { date: "2026-03-11", value: 11 },
+    ];
+    expect(computeAverage(values)).toBe(10.3);
+  });
+
+  it("handles a single non-null value", () => {
+    const values: DailyValue[] = [{ date: "2026-03-15", value: 7.5 }];
+    expect(computeAverage(values)).toBe(7.5);
+  });
+});
+
+// ─── aggregateHeartRate ───────────────────────────────────────────────────────
+
+type HRSample = { startDate: Date | string; quantity: number };
+
+describe("aggregateHeartRate", () => {
+  const endDate = D(2026, 3, 15);
+
+  it("returns 7 days all null when no samples", () => {
+    const result = aggregateHeartRate([], endDate);
+    expect(result).toHaveLength(7);
+    expect(result.every((r) => r.avg === null && r.min === null && r.max === null)).toBe(true);
+  });
+
+  it("computes avg/min/max for a day with multiple readings", () => {
+    const samples: HRSample[] = [
+      { startDate: D(2026, 3, 15), quantity: 60 },
+      { startDate: D(2026, 3, 15), quantity: 80 },
+      { startDate: D(2026, 3, 15), quantity: 100 },
+    ];
+    const result = aggregateHeartRate(samples, endDate);
+    const today = result.find((r) => r.date === "2026-03-15")!;
+    expect(today.avg).toBe(80);
+    expect(today.min).toBe(60);
+    expect(today.max).toBe(100);
+  });
+
+  it("returns null avg/min/max for days with no samples", () => {
+    const samples: HRSample[] = [
+      { startDate: D(2026, 3, 15), quantity: 72 },
+    ];
+    const result = aggregateHeartRate(samples, endDate);
+    const march14 = result.find((r) => r.date === "2026-03-14")!;
+    expect(march14.avg).toBeNull();
+    expect(march14.min).toBeNull();
+    expect(march14.max).toBeNull();
+  });
+
+  it("handles a single reading per day", () => {
+    const samples: HRSample[] = [
+      { startDate: D(2026, 3, 14), quantity: 65 },
+    ];
+    const result = aggregateHeartRate(samples, endDate);
+    const day = result.find((r) => r.date === "2026-03-14")!;
+    expect(day.avg).toBe(65);
+    expect(day.min).toBe(65);
+    expect(day.max).toBe(65);
+  });
+
+  it("rounds avg to 1 decimal place", () => {
+    const samples: HRSample[] = [
+      { startDate: D(2026, 3, 15), quantity: 60 },
+      { startDate: D(2026, 3, 15), quantity: 61 },
+      { startDate: D(2026, 3, 15), quantity: 62 },
+    ];
+    // avg = 183/3 = 61.0
+    const result = aggregateHeartRate(samples, endDate);
+    const today = result.find((r) => r.date === "2026-03-15")!;
+    expect(today.avg).toBe(61);
+  });
+
+  it("rounds avg correctly for non-integer result", () => {
+    const samples: HRSample[] = [
+      { startDate: D(2026, 3, 15), quantity: 70 },
+      { startDate: D(2026, 3, 15), quantity: 71 },
+    ];
+    // avg = 141/2 = 70.5
+    const result = aggregateHeartRate(samples, endDate);
+    const today = result.find((r) => r.date === "2026-03-15")!;
+    expect(today.avg).toBe(70.5);
+  });
+});
+
+// ─── aggregateSleep ───────────────────────────────────────────────────────────
+
+describe("aggregateSleep", () => {
+  const endDate = D(2026, 3, 15);
+
+  it("returns 7 null days when no samples", () => {
+    const result = aggregateSleep([], endDate);
+    expect(result).toHaveLength(7);
+    expect(result.every((r) => r.value === null)).toBe(true);
+  });
+
+  it("assigns sleep to the start date's local day", () => {
+    // Sleep starting on 2026-03-14 locally
+    const samples: SleepSample[] = [
+      {
+        startDate: new Date(2026, 2, 14, 23, 0), // local 2026-03-14 23:00
+        endDate: new Date(2026, 2, 15, 7, 0),    // local 2026-03-15 07:00
+      },
+    ];
+    const result = aggregateSleep(samples, endDate);
+    const march14 = result.find((r) => r.date === "2026-03-14")!;
+    expect(march14.value).toBe(8);
+    // March 15 should be null (sleep was assigned to the 14th)
+    const march15 = result.find((r) => r.date === "2026-03-15")!;
+    expect(march15.value).toBeNull();
+  });
+
+  it("merges overlapping samples for the same night", () => {
+    // Two overlapping sources for the same night (starts on 2026-03-13)
+    const samples: SleepSample[] = [
+      {
+        startDate: new Date(2026, 2, 13, 23, 0), // local 2026-03-13 23:00
+        endDate: new Date(2026, 2, 14, 7, 0),    // 8 hours
+      },
+      {
+        startDate: new Date(2026, 2, 13, 23, 30), // local 2026-03-13 23:30
+        endDate: new Date(2026, 2, 14, 6, 30),    // fully inside first
+      },
+    ];
+    const result = aggregateSleep(samples, endDate);
+    const march13 = result.find((r) => r.date === "2026-03-13")!;
+    expect(march13.value).toBe(8); // not 15
+  });
+
+  it("gaps appear as null", () => {
+    // Only one night out of 7
+    const samples: SleepSample[] = [
+      {
+        startDate: new Date(2026, 2, 15, 0, 0),
+        endDate: new Date(2026, 2, 15, 8, 0),
+      },
+    ];
+    const result = aggregateSleep(samples, endDate);
+    const nullDays = result.filter((r) => r.value === null);
+    expect(nullDays.length).toBe(6);
+  });
+});
+
+// ─── aggregateMeditation ─────────────────────────────────────────────────────
+
+describe("aggregateMeditation", () => {
+  const endDate = D(2026, 3, 15);
+
+  it("returns 7 null days when no sessions", () => {
+    const result = aggregateMeditation([], endDate);
+    expect(result).toHaveLength(7);
+    expect(result.every((r) => r.value === null)).toBe(true);
+  });
+
+  it("sums multiple sessions on the same day", () => {
+    const sessions: MindfulSession[] = [
+      {
+        startDate: new Date(2026, 2, 15, 8, 0),
+        endDate: new Date(2026, 2, 15, 8, 10), // 10 min
+      },
+      {
+        startDate: new Date(2026, 2, 15, 12, 0),
+        endDate: new Date(2026, 2, 15, 12, 20), // 20 min
+      },
+    ];
+    const result = aggregateMeditation(sessions, endDate);
+    const march15 = result.find((r) => r.date === "2026-03-15")!;
+    expect(march15.value).toBe(30);
+  });
+
+  it("clamps negative durations to zero", () => {
+    const sessions: MindfulSession[] = [
+      {
+        startDate: new Date(2026, 2, 15, 8, 10),
+        endDate: new Date(2026, 2, 15, 8, 0), // end before start
+      },
+      {
+        startDate: new Date(2026, 2, 15, 9, 0),
+        endDate: new Date(2026, 2, 15, 9, 15), // 15 min
+      },
+    ];
+    const result = aggregateMeditation(sessions, endDate);
+    const march15 = result.find((r) => r.date === "2026-03-15")!;
+    expect(march15.value).toBe(15);
+  });
+
+  it("gaps appear as null", () => {
+    const sessions: MindfulSession[] = [
+      {
+        startDate: new Date(2026, 2, 15, 8, 0),
+        endDate: new Date(2026, 2, 15, 8, 10),
+      },
+    ];
+    const result = aggregateMeditation(sessions, endDate);
+    const nullDays = result.filter((r) => r.value === null);
+    expect(nullDays.length).toBe(6);
+  });
+
+  it("handles a single session correctly", () => {
+    const sessions: MindfulSession[] = [
+      {
+        startDate: new Date(2026, 2, 12, 7, 0),
+        endDate: new Date(2026, 2, 12, 7, 20), // 20 min
+      },
+    ];
+    const result = aggregateMeditation(sessions, endDate);
+    const march12 = result.find((r) => r.date === "2026-03-12")!;
+    expect(march12.value).toBe(20);
+  });
+});
+
+// ─── pickLatestPerDay ─────────────────────────────────────────────────────────
+
+type WeightSample = { startDate: Date | string; quantity: number };
+
+describe("pickLatestPerDay", () => {
+  const endDate = D(2026, 3, 15);
+
+  it("returns 7 null days when no samples", () => {
+    const result = pickLatestPerDay([], endDate);
+    expect(result).toHaveLength(7);
+    expect(result.every((r) => r.value === null)).toBe(true);
+  });
+
+  it("picks the latest reading when multiple per day", () => {
+    const samples: WeightSample[] = [
+      { startDate: new Date(2026, 2, 15, 7, 0), quantity: 75.0 },  // earlier
+      { startDate: new Date(2026, 2, 15, 20, 0), quantity: 75.4 }, // later
+    ];
+    const result = pickLatestPerDay(samples, endDate);
+    const march15 = result.find((r) => r.date === "2026-03-15")!;
+    expect(march15.value).toBe(75.4);
+  });
+
+  it("rounds weight to 2 decimal places", () => {
+    const samples: WeightSample[] = [
+      { startDate: new Date(2026, 2, 15, 8, 0), quantity: 75.123 },
+    ];
+    const result = pickLatestPerDay(samples, endDate);
+    const march15 = result.find((r) => r.date === "2026-03-15")!;
+    expect(march15.value).toBe(75.12);
+  });
+
+  it("preserves gaps as null", () => {
+    const samples: WeightSample[] = [
+      { startDate: new Date(2026, 2, 15, 8, 0), quantity: 75.0 },
+    ];
+    const result = pickLatestPerDay(samples, endDate);
+    const nullDays = result.filter((r) => r.value === null);
+    expect(nullDays.length).toBe(6);
+  });
+
+  it("ignores samples outside the 7-day window", () => {
+    const samples: WeightSample[] = [
+      { startDate: new Date(2026, 2, 8, 8, 0), quantity: 75.0 }, // 8 days ago
+    ];
+    const result = pickLatestPerDay(samples, endDate);
+    expect(result.every((r) => r.value === null)).toBe(true);
+  });
+
+  it("handles one sample per day across multiple days", () => {
+    const samples: WeightSample[] = [
+      { startDate: new Date(2026, 2, 13, 8, 0), quantity: 74.5 },
+      { startDate: new Date(2026, 2, 14, 8, 0), quantity: 75.0 },
+      { startDate: new Date(2026, 2, 15, 8, 0), quantity: 75.5 },
+    ];
+    const result = pickLatestPerDay(samples, endDate);
+    expect(result.find((r) => r.date === "2026-03-13")!.value).toBe(74.5);
+    expect(result.find((r) => r.date === "2026-03-14")!.value).toBe(75.0);
+    expect(result.find((r) => r.date === "2026-03-15")!.value).toBe(75.5);
+  });
+});

--- a/components/BarChart.tsx
+++ b/components/BarChart.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { type DailyValue, formatDateKey } from "../lib/weekly";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHART_HEIGHT = 200;
+const LABEL_HEIGHT = 30;
+const BAR_RADIUS = 4;
+const DASH_HEIGHT = 2;
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+type Props = {
+  data: DailyValue[];
+  color: string;
+  unit: string;
+};
+
+// ─── BarChart ─────────────────────────────────────────────────────────────────
+
+export default function BarChart({ data, color, unit }: Props): React.JSX.Element {
+  const today = formatDateKey(new Date());
+
+  // Compute the max value across the week (non-null only).
+  const maxValue = data.reduce<number>((acc, d) => {
+    if (d.value !== null && d.value > acc) return d.value;
+    return acc;
+  }, 0);
+
+  // Dim color for non-today bars: append "4D" (30% opacity) to the hex string.
+  const dimColor = `${color}4D`;
+
+  return (
+    <View style={styles.container}>
+      {/* Bar area */}
+      <View style={[styles.chartArea, { height: CHART_HEIGHT }]}>
+        {data.map((day) => {
+          const isToday = day.date === today;
+          const barColor = isToday ? color : dimColor;
+
+          // Determine the day-of-week label by parsing date as UTC midnight.
+          const parsed = new Date(`${day.date}T00:00:00Z`);
+          const dayLabel = DAY_LABELS[parsed.getUTCDay()];
+
+          if (day.value === null) {
+            // Null day: render a small dash centred at the bottom of the chart area.
+            return (
+              <View key={day.date} style={styles.barColumn}>
+                <View style={styles.barWrapper}>
+                  <View
+                    style={[
+                      styles.dash,
+                      { backgroundColor: barColor },
+                    ]}
+                  />
+                </View>
+                <Text style={[styles.dayLabel, isToday && { color }]}>
+                  {dayLabel}
+                </Text>
+              </View>
+            );
+          }
+
+          // Height proportional to maxValue; guard against divide-by-zero.
+          const heightFraction = maxValue > 0 ? day.value / maxValue : 0;
+          const barHeight = Math.max(4, Math.round(heightFraction * CHART_HEIGHT));
+
+          return (
+            <View key={day.date} style={styles.barColumn}>
+              <View style={styles.barWrapper}>
+                <View
+                  style={[
+                    styles.bar,
+                    {
+                      height: barHeight,
+                      backgroundColor: barColor,
+                      borderRadius: BAR_RADIUS,
+                    },
+                  ]}
+                />
+              </View>
+              <Text style={[styles.dayLabel, isToday && { color }]}>
+                {dayLabel}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+
+      {/* Unit label */}
+      <Text style={styles.unitLabel}>{unit}</Text>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+  },
+  chartArea: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    paddingBottom: LABEL_HEIGHT,
+  },
+  barColumn: {
+    flex: 1,
+    alignItems: "center",
+  },
+  barWrapper: {
+    flex: 1,
+    justifyContent: "flex-end",
+    alignItems: "center",
+    width: "100%",
+  },
+  bar: {
+    width: "60%",
+  },
+  dash: {
+    width: "40%",
+    height: DASH_HEIGHT,
+    borderRadius: 1,
+  },
+  dayLabel: {
+    position: "absolute",
+    bottom: 0,
+    fontSize: 11,
+    color: "#888",
+    textAlign: "center",
+    height: LABEL_HEIGHT,
+    lineHeight: LABEL_HEIGHT,
+  },
+  unitLabel: {
+    fontSize: 11,
+    color: "#888",
+    textAlign: "center",
+    marginTop: 4,
+  },
+});

--- a/components/BarChart.tsx
+++ b/components/BarChart.tsx
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 0,
     fontSize: 11,
-    color: "#888",
+    color: "#666",
     textAlign: "center",
     height: LABEL_HEIGHT,
     lineHeight: LABEL_HEIGHT,

--- a/components/LineChart.tsx
+++ b/components/LineChart.tsx
@@ -227,6 +227,6 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 11,
-    color: "#888",
+    color: "#666",
   },
 });

--- a/components/LineChart.tsx
+++ b/components/LineChart.tsx
@@ -1,0 +1,232 @@
+import React from "react";
+import { View, Text, StyleSheet, type DimensionValue } from "react-native";
+import { type DailyValue, type HeartRateDaily, formatDateKey } from "../lib/weekly";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Props = {
+  data: DailyValue[] | HeartRateDaily[];
+  color: string;
+  unit: string;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHART_HEIGHT = 200;
+const LABEL_HEIGHT = 30;
+const DOT_RADIUS = 5;
+const PADDING_V = 10; // vertical padding inside chart area
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function isHeartRateData(data: DailyValue[] | HeartRateDaily[]): data is HeartRateDaily[] {
+  return data.length > 0 && "avg" in data[0];
+}
+
+function getDayLabel(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  return DAY_LABELS[d.getUTCDay()];
+}
+
+// Returns the primary value for a data point (avg for HR, value otherwise).
+function getPrimaryValue(item: DailyValue | HeartRateDaily): number | null {
+  if ("avg" in item) return item.avg;
+  return item.value;
+}
+
+// Compute vertical position (0 = top, 1 = bottom) for a given value.
+function valueToRatio(value: number, min: number, max: number): number {
+  if (max === min) return 0.5;
+  return (max - value) / (max - min);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function LineChart({ data, color, unit }: Props): React.ReactElement {
+  const today = formatDateKey(new Date());
+  const isHR = isHeartRateData(data);
+
+  // Gather all non-null primary values to compute scale.
+  const allValues: number[] = data
+    .map((item) => getPrimaryValue(item))
+    .filter((v): v is number => v !== null);
+
+  const allNull = allValues.length === 0;
+
+  if (allNull) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.noDataContainer}>
+          <Text style={styles.noDataText}>No data</Text>
+        </View>
+      </View>
+    );
+  }
+
+  // Also include HR min/max in scale so range bands fit.
+  const scaleValues = [...allValues];
+  if (isHR) {
+    for (const item of data as HeartRateDaily[]) {
+      if (item.min !== null) scaleValues.push(item.min);
+      if (item.max !== null) scaleValues.push(item.max);
+    }
+  }
+
+  const scaleMin = Math.min(...scaleValues);
+  const scaleMax = Math.max(...scaleValues);
+
+  // Usable vertical range inside chart (excluding top/bottom padding).
+  const usableHeight = CHART_HEIGHT - PADDING_V * 2;
+
+  function ratioToTop(value: number): number {
+    return PADDING_V + valueToRatio(value, scaleMin, scaleMax) * usableHeight;
+  }
+
+  const count = data.length;
+  // Horizontal position: percentage-based for each index.
+  function leftPercent(i: number): DimensionValue {
+    return `${(i / Math.max(count - 1, 1)) * 100}%` as DimensionValue;
+  }
+
+  return (
+    <View style={styles.container}>
+      {/* Chart area */}
+      <View style={[styles.chartArea, { height: CHART_HEIGHT }]}>
+        {data.map((item, i) => {
+          const primaryVal = getPrimaryValue(item);
+          const isToday = item.date === today;
+          const dotColor = isToday ? color : `${color}99`;
+
+          // Horizontal label below
+          const left = leftPercent(i);
+
+          // Range band for heart rate
+          let rangeBand: React.ReactElement | null = null;
+          if (isHR) {
+            const hrItem = item as HeartRateDaily;
+            if (hrItem.min !== null && hrItem.max !== null) {
+              const topPos = ratioToTop(hrItem.max);
+              const bottomPos = ratioToTop(hrItem.min);
+              const bandHeight = bottomPos - topPos;
+              rangeBand = (
+                <View
+                  key={`band-${i}`}
+                  style={[
+                    styles.rangeBand,
+                    {
+                      left,
+                      top: topPos,
+                      height: Math.max(bandHeight, 2),
+                      backgroundColor: `${color}26`,
+                      transform: [{ translateX: -6 }],
+                      width: 12,
+                    },
+                  ]}
+                />
+              );
+            }
+          }
+
+          // Dot
+          let dot: React.ReactElement | null = null;
+          if (primaryVal !== null) {
+            const topPos = ratioToTop(primaryVal) - DOT_RADIUS;
+            dot = (
+              <View
+                key={`dot-${i}`}
+                style={[
+                  styles.dot,
+                  {
+                    left,
+                    top: topPos,
+                    backgroundColor: dotColor,
+                    transform: [{ translateX: -DOT_RADIUS }],
+                    width: DOT_RADIUS * 2,
+                    height: DOT_RADIUS * 2,
+                    borderRadius: DOT_RADIUS,
+                    borderWidth: isToday ? 2 : 0,
+                    borderColor: isToday ? "white" : "transparent",
+                  },
+                ]}
+              />
+            );
+          }
+
+          return (
+            <React.Fragment key={item.date}>
+              {rangeBand}
+              {dot}
+            </React.Fragment>
+          );
+        })}
+      </View>
+
+      {/* Day labels */}
+      <View style={styles.labelsRow}>
+        {data.map((item, i) => {
+          const isToday = item.date === today;
+          return (
+            <View
+              key={item.date}
+              style={[
+                styles.labelWrapper,
+                {
+                  left: leftPercent(i),
+                  transform: [{ translateX: -16 }],
+                },
+              ]}
+            >
+              <Text style={[styles.label, isToday && { color, fontWeight: "600" }]}>
+                {getDayLabel(item.date)}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+  },
+  chartArea: {
+    position: "relative",
+    width: "100%",
+  },
+  noDataContainer: {
+    height: CHART_HEIGHT + LABEL_HEIGHT,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  noDataText: {
+    color: "#888",
+    fontSize: 14,
+  },
+  rangeBand: {
+    position: "absolute",
+    borderRadius: 3,
+  },
+  dot: {
+    position: "absolute",
+  },
+  labelsRow: {
+    position: "relative",
+    height: LABEL_HEIGHT,
+    width: "100%",
+  },
+  labelWrapper: {
+    position: "absolute",
+    width: 32,
+    alignItems: "center",
+  },
+  label: {
+    fontSize: 11,
+    color: "#888",
+  },
+});

--- a/components/MetricDetailSheet.tsx
+++ b/components/MetricDetailSheet.tsx
@@ -1,0 +1,410 @@
+import React, { useEffect, useRef } from "react";
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  PanResponder,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableWithoutFeedback,
+  View,
+  ActivityIndicator,
+} from "react-native";
+import {
+  METRIC_CONFIG,
+  computeAverage,
+  type MetricKey,
+  type DailyValue,
+  type HeartRateDaily,
+} from "../lib/weekly";
+import { formatNumber } from "../lib/summary";
+import BarChart from "./BarChart";
+import LineChart from "./LineChart";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type MetricDetailSheetProps = {
+  metricKey: MetricKey;
+  currentValue: string;
+  currentSublabel: string;
+  data: DailyValue[] | HeartRateDaily[] | null; // null = loading
+  error: string | null;
+  onClose: () => void;
+};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DISMISS_THRESHOLD = 100;
+const SWIPE_START_THRESHOLD = 10;
+const ANIMATION_DURATION = 300;
+const OVERLAY_MAX_OPACITY = 0.6;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDayRow(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  return `${days[d.getUTCDay()]}, ${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+function isHeartRateData(
+  data: DailyValue[] | HeartRateDaily[],
+): data is HeartRateDaily[] {
+  return data.length > 0 && "avg" in data[0];
+}
+
+function formatHeartRateRow(item: HeartRateDaily): string {
+  if (item.avg === null) return "—";
+  const avg = Math.round(item.avg);
+  if (item.min !== null && item.max !== null) {
+    return `${avg} avg (${Math.round(item.min)}–${Math.round(item.max)})`;
+  }
+  return `${avg}`;
+}
+
+function formatDailyValue(item: DailyValue, unit: string): string {
+  if (item.value === null) return "—";
+  const formatted = Number.isInteger(item.value)
+    ? formatNumber(item.value)
+    : item.value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+  return `${formatted} ${unit}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function MetricDetailSheet({
+  metricKey,
+  currentValue,
+  currentSublabel,
+  data,
+  error,
+  onClose,
+}: MetricDetailSheetProps): React.ReactElement {
+  const screenHeight = Dimensions.get("window").height;
+  const config = METRIC_CONFIG[metricKey];
+
+  // Single animated value drives translateY (0 = visible) and overlay opacity.
+  const animValue = useRef(new Animated.Value(0)).current;
+
+  // Secondary animated value for snap-back during pan gesture.
+  const panOffset = useRef(new Animated.Value(0)).current;
+
+  // Entry animation on mount.
+  useEffect(() => {
+    Animated.timing(animValue, {
+      toValue: 1,
+      duration: ANIMATION_DURATION,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [animValue]);
+
+  function dismiss() {
+    Animated.timing(animValue, {
+      toValue: 0,
+      duration: ANIMATION_DURATION,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start(() => onClose());
+  }
+
+  // Derived animated styles from animValue (0 = offscreen, 1 = visible).
+  const sheetTranslateY = animValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: [screenHeight, 0],
+  });
+
+  const overlayOpacity = animValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, OVERLAY_MAX_OPACITY],
+  });
+
+  // Combined translateY: entry animation + pan offset.
+  const combinedTranslateY = Animated.add(sheetTranslateY, panOffset);
+
+  // PanResponder for swipe-to-dismiss on header+chart zone only.
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_evt, gestureState) =>
+        gestureState.dy > SWIPE_START_THRESHOLD,
+      onPanResponderMove: (_evt, gestureState) => {
+        // Clamp to >= 0 (no upward drag past 0).
+        const clamped = Math.max(0, gestureState.dy);
+        panOffset.setValue(clamped);
+      },
+      onPanResponderRelease: (_evt, gestureState) => {
+        if (gestureState.dy > DISMISS_THRESHOLD) {
+          dismiss();
+        } else {
+          // Snap back.
+          Animated.timing(panOffset, {
+            toValue: 0,
+            duration: 200,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }).start();
+        }
+      },
+      onPanResponderTerminate: () => {
+        Animated.timing(panOffset, {
+          toValue: 0,
+          duration: 200,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }).start();
+      },
+    }),
+  ).current;
+
+  // ─── Average ────────────────────────────────────────────────────────────────
+
+  let averageText: string | null = null;
+  if (data !== null && !error) {
+    if (isHeartRateData(data)) {
+      // Build DailyValue array from avg values for computeAverage.
+      const asDaily: DailyValue[] = data.map((d) => ({
+        date: d.date,
+        value: d.avg,
+      }));
+      const avg = computeAverage(asDaily);
+      if (avg !== null) {
+        averageText = `Avg: ${formatNumber(Math.round(avg))} ${config.unit}/day`;
+      }
+    } else {
+      const avg = computeAverage(data);
+      if (avg !== null) {
+        const formatted = Number.isInteger(avg)
+          ? formatNumber(avg)
+          : avg.toLocaleString("en-US", { maximumFractionDigits: 2 });
+        averageText = `Avg: ${formatted} ${config.unit}/day`;
+      }
+    }
+  }
+
+  // ─── Daily rows (most recent first) ─────────────────────────────────────────
+
+  let dailyRows: React.ReactElement[] | null = null;
+  if (data !== null && !error) {
+    const reversed = [...data].reverse();
+    const isHR = isHeartRateData(reversed as DailyValue[] | HeartRateDaily[]);
+
+    dailyRows = reversed.map((item, index) => {
+      const dayLabel = formatDayRow(item.date);
+      const valueLabel = isHR
+        ? formatHeartRateRow(item as HeartRateDaily)
+        : formatDailyValue(item as DailyValue, config.unit);
+
+      return (
+        <View
+          key={item.date}
+          style={[styles.dayRow, index > 0 && styles.dayRowDivider]}
+        >
+          <Text style={styles.dayRowLabel}>{dayLabel}</Text>
+          <Text style={styles.dayRowValue}>{valueLabel}</Text>
+        </View>
+      );
+    });
+  }
+
+  // ─── Chart ──────────────────────────────────────────────────────────────────
+
+  let chartContent: React.ReactElement;
+  if (data === null) {
+    chartContent = (
+      <View style={styles.chartPlaceholder}>
+        <ActivityIndicator color={config.color} size="large" />
+      </View>
+    );
+  } else if (error) {
+    chartContent = (
+      <View style={styles.chartPlaceholder}>
+        <Text style={styles.errorText}>{error}</Text>
+      </View>
+    );
+  } else if (config.chartType === "bar") {
+    chartContent = (
+      <BarChart data={data as DailyValue[]} color={config.color} unit={config.unit} />
+    );
+  } else {
+    chartContent = (
+      <LineChart data={data} color={config.color} unit={config.unit} />
+    );
+  }
+
+  // ─── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      {/* Overlay — taps dismiss */}
+      <TouchableWithoutFeedback onPress={dismiss}>
+        <Animated.View style={[styles.overlay, { opacity: overlayOpacity }]} />
+      </TouchableWithoutFeedback>
+
+      {/* Sheet */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          { transform: [{ translateY: combinedTranslateY }] },
+        ]}
+      >
+        {/* PanResponder zone: drag handle + header + current value + chart */}
+        <View {...panResponder.panHandlers}>
+          {/* Drag handle */}
+          <View style={styles.dragHandleRow}>
+            <View style={styles.dragHandle} />
+          </View>
+
+          {/* Header */}
+          <View style={styles.header}>
+            <Text style={[styles.headerTitle, { color: config.color }]}>
+              {config.label}
+            </Text>
+            <Text style={styles.closeButton} onPress={dismiss}>
+              ✕
+            </Text>
+          </View>
+
+          {/* Current value */}
+          <View style={styles.currentValueContainer}>
+            <Text style={styles.currentValue}>{currentValue}</Text>
+            <Text style={styles.currentSublabel}>{currentSublabel}</Text>
+          </View>
+
+          {/* Chart */}
+          <View style={styles.chartContainer}>{chartContent}</View>
+
+          {/* Average line */}
+          {averageText !== null && (
+            <Text style={[styles.averageText, { color: config.color }]}>
+              {averageText}
+            </Text>
+          )}
+        </View>
+
+        {/* Daily breakdown — separate from PanResponder */}
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {dailyRows}
+        </ScrollView>
+      </Animated.View>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "black",
+  },
+  sheet: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: "#111828",
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    maxHeight: "90%",
+  },
+  dragHandleRow: {
+    alignItems: "center",
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  dragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "#444",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 20,
+    paddingBottom: 8,
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  closeButton: {
+    fontSize: 18,
+    color: "#888",
+    paddingLeft: 16,
+    paddingVertical: 4,
+  },
+  currentValueContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 12,
+  },
+  currentValue: {
+    fontSize: 36,
+    fontWeight: "700",
+    color: "white",
+  },
+  currentSublabel: {
+    fontSize: 13,
+    color: "#888",
+    marginTop: 2,
+  },
+  chartContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 8,
+  },
+  chartPlaceholder: {
+    height: 230,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  errorText: {
+    color: "#888",
+    fontSize: 14,
+    textAlign: "center",
+  },
+  averageText: {
+    fontSize: 13,
+    textAlign: "center",
+    paddingBottom: 12,
+  },
+  scrollView: {
+    flexShrink: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingBottom: 32,
+  },
+  dayRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+  dayRowDivider: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#222",
+  },
+  dayRowLabel: {
+    fontSize: 14,
+    color: "#ccc",
+  },
+  dayRowValue: {
+    fontSize: 14,
+    color: "white",
+    fontWeight: "500",
+  },
+});

--- a/components/MetricDetailSheet.tsx
+++ b/components/MetricDetailSheet.tsx
@@ -355,7 +355,7 @@ const styles = StyleSheet.create({
   currentValue: {
     fontSize: 36,
     fontWeight: "700",
-    color: "white",
+    color: "#e0e0e0",
   },
   currentSublabel: {
     fontSize: 13,
@@ -377,7 +377,8 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   averageText: {
-    fontSize: 13,
+    fontSize: 14,
+    fontWeight: "600",
     textAlign: "center",
     paddingBottom: 12,
   },
@@ -399,12 +400,12 @@ const styles = StyleSheet.create({
     borderTopColor: "#222",
   },
   dayRowLabel: {
-    fontSize: 14,
-    color: "#ccc",
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#e0e0e0",
   },
   dayRowValue: {
-    fontSize: 14,
-    color: "white",
-    fontWeight: "500",
+    fontSize: 15,
+    color: "#aaa",
   },
 });

--- a/docs/superpowers/plans/2026-03-15-7-day-metric-detail.md
+++ b/docs/superpowers/plans/2026-03-15-7-day-metric-detail.md
@@ -1,0 +1,1880 @@
+# 7-Day Metric Detail View Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add tap-to-drill-down on metric cards showing a 7-day chart and daily breakdown for each health metric.
+
+**Architecture:** New `lib/weekly.ts` for pure data aggregation functions, new `components/` directory with `MetricDetailSheet`, `BarChart`, and `LineChart` components. HealthKit weekly queries live in `App.tsx` alongside existing health queries. Single `Animated.Value` drives a slide-up sheet overlay.
+
+**Tech Stack:** React Native Animated API, pure RN Views for charts, existing HealthKit library (`@kingstinct/react-native-healthkit`), Jest + ts-jest for testing.
+
+**Spec:** `docs/superpowers/specs/2026-03-15-7-day-metric-detail-design.md`
+
+---
+
+## Chunk 1: Data Layer (`lib/weekly.ts` + tests)
+
+### Task 1: Types and configuration — `lib/weekly.ts`
+
+**Files:**
+- Create: `lib/weekly.ts`
+- Test: `__tests__/weekly.test.ts`
+
+- [ ] **Step 1: Create `lib/weekly.ts` with types and METRIC_CONFIG**
+
+```typescript
+// lib/weekly.ts
+
+export type MetricKey =
+  | "steps"
+  | "heartRate"
+  | "sleep"
+  | "activeEnergy"
+  | "walkingDistance"
+  | "weight"
+  | "meditation";
+
+export type ChartType = "bar" | "line";
+
+export type MetricConfig = {
+  label: string;
+  unit: string;
+  color: string;
+  chartType: ChartType;
+  sublabel: string;
+};
+
+export const METRIC_CONFIG: Record<MetricKey, MetricConfig> = {
+  steps: {
+    label: "Steps",
+    unit: "steps",
+    color: "#4cc9f0",
+    chartType: "bar",
+    sublabel: "today",
+  },
+  heartRate: {
+    label: "Heart Rate",
+    unit: "bpm",
+    color: "#f72585",
+    chartType: "line",
+    sublabel: "latest",
+  },
+  sleep: {
+    label: "Sleep",
+    unit: "hrs",
+    color: "#7b2cbf",
+    chartType: "bar",
+    sublabel: "last night",
+  },
+  activeEnergy: {
+    label: "Active Energy",
+    unit: "kcal",
+    color: "#ff9e00",
+    chartType: "bar",
+    sublabel: "today",
+  },
+  walkingDistance: {
+    label: "Walking Distance",
+    unit: "km",
+    color: "#06d6a0",
+    chartType: "bar",
+    sublabel: "today",
+  },
+  weight: {
+    label: "Weight",
+    unit: "kg",
+    color: "#4895ef",
+    chartType: "line",
+    sublabel: "latest",
+  },
+  meditation: {
+    label: "Meditation",
+    unit: "min",
+    color: "#e0aaff",
+    chartType: "bar",
+    sublabel: "today",
+  },
+};
+
+export type DailyValue = {
+  date: string; // "YYYY-MM-DD"
+  value: number | null;
+};
+
+export type HeartRateDaily = {
+  date: string; // "YYYY-MM-DD"
+  avg: number | null;
+  min: number | null;
+  max: number | null;
+};
+```
+
+- [ ] **Step 2: Verify file compiles**
+
+Run: `npx tsc --noEmit lib/weekly.ts`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/weekly.ts
+git commit -m "feat: add weekly types and metric config"
+```
+
+---
+
+### Task 2: `bucketByDay` — generic day-bucketing
+
+**Files:**
+- Modify: `lib/weekly.ts`
+- Create: `__tests__/weekly.test.ts`
+
+- [ ] **Step 1: Write failing tests for `bucketByDay`**
+
+Create `__tests__/weekly.test.ts`:
+
+```typescript
+import { bucketByDay, type DailyValue } from "../lib/weekly";
+
+describe("bucketByDay", () => {
+  it("returns 7 days with null values when no samples", () => {
+    const result = bucketByDay([], new Date(2026, 2, 15), 7, (items) =>
+      items.length > 0 ? items.reduce((a, b) => a + b, 0) : null,
+    );
+    expect(result).toHaveLength(7);
+    expect(result.every((d) => d.value === null)).toBe(true);
+    expect(result[0].date).toBe("2026-03-09");
+    expect(result[6].date).toBe("2026-03-15");
+  });
+
+  it("buckets samples into correct days", () => {
+    const samples = [
+      { date: new Date("2026-03-15T10:00:00Z"), value: 100 },
+      { date: new Date("2026-03-15T14:00:00Z"), value: 200 },
+      { date: new Date("2026-03-14T08:00:00Z"), value: 50 },
+    ];
+    const result = bucketByDay(
+      samples,
+      new Date(2026, 2, 15),
+      7,
+      (items) => (items.length > 0 ? items.reduce((a, b) => a + b, 0) : null),
+    );
+    // Mar 15 = index 6, Mar 14 = index 5
+    expect(result[6].value).toBe(300);
+    expect(result[5].value).toBe(50);
+    expect(result[4].value).toBeNull(); // Mar 13
+  });
+
+  it("ignores samples outside the date range", () => {
+    const samples = [
+      { date: new Date("2026-03-01T10:00:00Z"), value: 999 },
+      { date: new Date("2026-03-15T10:00:00Z"), value: 100 },
+    ];
+    const result = bucketByDay(
+      samples,
+      new Date(2026, 2, 15),
+      7,
+      (items) => (items.length > 0 ? items.reduce((a, b) => a + b, 0) : null),
+    );
+    expect(result[6].value).toBe(100);
+    // Mar 1 is outside the 7-day window, should not appear
+    expect(result.every((d, i) => i === 6 || d.value === null)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: FAIL — `bucketByDay` not found
+
+- [ ] **Step 3: Implement `bucketByDay`**
+
+Add to `lib/weekly.ts`:
+
+```typescript
+/**
+ * Format a Date as "YYYY-MM-DD" in local time.
+ * Uses local time to match HealthKit's day boundaries (consistent with grabHealthData).
+ */
+export function formatDateKey(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Generic day-bucketing. Takes samples with a date and numeric value,
+ * buckets them into `days` calendar days ending at `endDate`,
+ * and applies `aggregate` to each day's values.
+ */
+export function bucketByDay(
+  samples: { date: Date; value: number }[],
+  endDate: Date,
+  days: number,
+  aggregate: (values: number[]) => number | null,
+): DailyValue[] {
+  // Build date keys for each day in range
+  const result: DailyValue[] = [];
+  const buckets = new Map<string, number[]>();
+
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    const key = formatDateKey(d);
+    result.push({ date: key, value: null });
+    buckets.set(key, []);
+  }
+
+  // Sort samples into buckets
+  for (const sample of samples) {
+    const key = formatDateKey(sample.date);
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.push(sample.value);
+    }
+  }
+
+  // Aggregate each bucket
+  for (const day of result) {
+    const bucket = buckets.get(day.date)!;
+    day.value = aggregate(bucket);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: PASS — all 3 tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/weekly.ts __tests__/weekly.test.ts
+git commit -m "feat: add bucketByDay generic day-bucketing function"
+```
+
+---
+
+### Task 3: `computeAverage`
+
+**Files:**
+- Modify: `lib/weekly.ts`
+- Modify: `__tests__/weekly.test.ts`
+
+- [ ] **Step 1: Write failing tests for `computeAverage`**
+
+Append to `__tests__/weekly.test.ts`:
+
+```typescript
+import { computeAverage } from "../lib/weekly";
+
+describe("computeAverage", () => {
+  it("returns null for empty array", () => {
+    expect(computeAverage([])).toBeNull();
+  });
+
+  it("returns null when all values are null", () => {
+    expect(
+      computeAverage([
+        { date: "2026-03-15", value: null },
+        { date: "2026-03-14", value: null },
+      ]),
+    ).toBeNull();
+  });
+
+  it("averages non-null values, ignoring nulls", () => {
+    const result = computeAverage([
+      { date: "2026-03-15", value: 100 },
+      { date: "2026-03-14", value: null },
+      { date: "2026-03-13", value: 200 },
+    ]);
+    expect(result).toBe(150);
+  });
+
+  it("rounds to one decimal place", () => {
+    const result = computeAverage([
+      { date: "2026-03-15", value: 10 },
+      { date: "2026-03-14", value: 10 },
+      { date: "2026-03-13", value: 11 },
+    ]);
+    expect(result).toBe(10.3);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: FAIL — `computeAverage` not found
+
+- [ ] **Step 3: Implement `computeAverage`**
+
+Add to `lib/weekly.ts`:
+
+```typescript
+/**
+ * Compute the average of non-null DailyValues.
+ * Returns null if no non-null values exist.
+ * Rounds to one decimal place.
+ */
+export function computeAverage(values: DailyValue[]): number | null {
+  const nonNull = values.filter((v) => v.value !== null);
+  if (nonNull.length === 0) return null;
+  const sum = nonNull.reduce((acc, v) => acc + v.value!, 0);
+  return Math.round((sum / nonNull.length) * 10) / 10;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/weekly.ts __tests__/weekly.test.ts
+git commit -m "feat: add computeAverage for 7-day summary line"
+```
+
+---
+
+### Task 4: `aggregateHeartRate`
+
+**Files:**
+- Modify: `lib/weekly.ts`
+- Modify: `__tests__/weekly.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `__tests__/weekly.test.ts`:
+
+```typescript
+import { aggregateHeartRate, type HeartRateDaily } from "../lib/weekly";
+
+describe("aggregateHeartRate", () => {
+  it("returns 7 days with null values when no samples", () => {
+    const result = aggregateHeartRate([], new Date(2026, 2, 15));
+    expect(result).toHaveLength(7);
+    expect(result[0]).toEqual({
+      date: "2026-03-09",
+      avg: null,
+      min: null,
+      max: null,
+    });
+  });
+
+  it("computes avg/min/max per day", () => {
+    const samples = [
+      { date: new Date("2026-03-15T10:00:00Z"), value: 60 },
+      { date: new Date("2026-03-15T14:00:00Z"), value: 80 },
+      { date: new Date("2026-03-15T18:00:00Z"), value: 100 },
+    ];
+    const result = aggregateHeartRate(samples, new Date(2026, 2, 15));
+    const today = result[6];
+    expect(today.avg).toBe(80);
+    expect(today.min).toBe(60);
+    expect(today.max).toBe(100);
+  });
+
+  it("handles single reading per day", () => {
+    const samples = [
+      { date: new Date("2026-03-14T08:00:00Z"), value: 72 },
+    ];
+    const result = aggregateHeartRate(samples, new Date(2026, 2, 15));
+    const yesterday = result[5];
+    expect(yesterday.avg).toBe(72);
+    expect(yesterday.min).toBe(72);
+    expect(yesterday.max).toBe(72);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: FAIL — `aggregateHeartRate` not found
+
+- [ ] **Step 3: Implement `aggregateHeartRate`**
+
+Add to `lib/weekly.ts`:
+
+```typescript
+/**
+ * Aggregate heart rate samples into daily avg/min/max.
+ */
+export function aggregateHeartRate(
+  samples: { date: Date; value: number }[],
+  endDate: Date,
+): HeartRateDaily[] {
+  const result: HeartRateDaily[] = [];
+  const buckets = new Map<string, number[]>();
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    const key = formatDateKey(d);
+    result.push({ date: key, avg: null, min: null, max: null });
+    buckets.set(key, []);
+  }
+
+  for (const sample of samples) {
+    const key = formatDateKey(sample.date);
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.push(sample.value);
+    }
+  }
+
+  for (const day of result) {
+    const bucket = buckets.get(day.date)!;
+    if (bucket.length > 0) {
+      day.avg = Math.round(bucket.reduce((a, b) => a + b, 0) / bucket.length);
+      day.min = Math.min(...bucket);
+      day.max = Math.max(...bucket);
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/weekly.ts __tests__/weekly.test.ts
+git commit -m "feat: add aggregateHeartRate for daily avg/min/max"
+```
+
+---
+
+### Task 5: `aggregateSleep`
+
+**Files:**
+- Modify: `lib/weekly.ts`
+- Modify: `__tests__/weekly.test.ts`
+
+The sleep aggregation reuses the overlap-merge algorithm from `lib/health.ts` (`calculateSleepHours`). Import `SleepSample` type and `calculateSleepHours` from `lib/health.ts`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `__tests__/weekly.test.ts`:
+
+```typescript
+import { aggregateSleep } from "../lib/weekly";
+
+describe("aggregateSleep", () => {
+  it("returns 7 days with null when no samples", () => {
+    const result = aggregateSleep([], new Date(2026, 2, 15));
+    expect(result).toHaveLength(7);
+    expect(result.every((d) => d.value === null)).toBe(true);
+  });
+
+  it("assigns sleep to the night's start date", () => {
+    // Sleep from Mar 14 11pm to Mar 15 7am = 8hrs, assigned to Mar 14
+    const samples = [
+      {
+        startDate: "2026-03-14T23:00:00.000Z",
+        endDate: "2026-03-15T07:00:00.000Z",
+      },
+    ];
+    const result = aggregateSleep(samples, new Date(2026, 2, 15));
+    // Mar 14 is index 5 (6 days ago from Mar 15... wait: Mar 9=0, Mar 10=1, ..., Mar 14=5, Mar 15=6)
+    expect(result[5].date).toBe("2026-03-14");
+    expect(result[5].value).toBe(8);
+    expect(result[6].value).toBeNull(); // Mar 15 has no sleep starting that night
+  });
+
+  it("merges overlapping samples from multiple sources per night", () => {
+    const samples = [
+      {
+        startDate: "2026-03-14T23:00:00.000Z",
+        endDate: "2026-03-15T07:00:00.000Z",
+      },
+      {
+        startDate: "2026-03-14T23:30:00.000Z",
+        endDate: "2026-03-15T06:30:00.000Z",
+      },
+    ];
+    const result = aggregateSleep(samples, new Date(2026, 2, 15));
+    expect(result[5].value).toBe(8); // merged, not 15
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: FAIL — `aggregateSleep` not found
+
+- [ ] **Step 3: Implement `aggregateSleep`**
+
+Add to `lib/weekly.ts`:
+
+```typescript
+import { calculateSleepHours, type SleepSample } from "./health";
+
+/**
+ * Aggregate sleep samples into daily hours.
+ * Each sample is assigned to the local date of its startDate.
+ * Uses calculateSleepHours (overlap-merge) per day.
+ */
+export function aggregateSleep(
+  samples: SleepSample[],
+  endDate: Date,
+): DailyValue[] {
+  const result: DailyValue[] = [];
+  const buckets = new Map<string, SleepSample[]>();
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    const key = formatDateKey(d);
+    result.push({ date: key, value: null });
+    buckets.set(key, []);
+  }
+
+  for (const sample of samples) {
+    const key = formatDateKey(new Date(sample.startDate));
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.push(sample);
+    }
+  }
+
+  for (const day of result) {
+    const bucket = buckets.get(day.date)!;
+    if (bucket.length > 0) {
+      day.value = calculateSleepHours(bucket);
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/weekly.ts __tests__/weekly.test.ts
+git commit -m "feat: add aggregateSleep with per-night overlap merge"
+```
+
+---
+
+### Task 6: `aggregateMeditation` and `pickLatestPerDay`
+
+**Files:**
+- Modify: `lib/weekly.ts`
+- Modify: `__tests__/weekly.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `__tests__/weekly.test.ts`:
+
+```typescript
+import { aggregateMeditation, pickLatestPerDay } from "../lib/weekly";
+
+describe("aggregateMeditation", () => {
+  it("returns 7 days with null when no sessions", () => {
+    const result = aggregateMeditation([], new Date(2026, 2, 15));
+    expect(result).toHaveLength(7);
+    expect(result.every((d) => d.value === null)).toBe(true);
+  });
+
+  it("sums session minutes per day", () => {
+    const sessions = [
+      {
+        startDate: "2026-03-15T08:00:00.000Z",
+        endDate: "2026-03-15T08:10:00.000Z", // 10 min
+      },
+      {
+        startDate: "2026-03-15T12:00:00.000Z",
+        endDate: "2026-03-15T12:20:00.000Z", // 20 min
+      },
+    ];
+    const result = aggregateMeditation(sessions, new Date(2026, 2, 15));
+    expect(result[6].value).toBe(30);
+  });
+
+  it("clamps negative durations to zero", () => {
+    const sessions = [
+      {
+        startDate: "2026-03-15T12:00:00.000Z",
+        endDate: "2026-03-15T11:00:00.000Z", // negative
+      },
+    ];
+    const result = aggregateMeditation(sessions, new Date(2026, 2, 15));
+    expect(result[6].value).toBe(0);
+  });
+});
+
+describe("pickLatestPerDay", () => {
+  it("returns 7 days with null when no samples", () => {
+    const result = pickLatestPerDay([], new Date(2026, 2, 15));
+    expect(result).toHaveLength(7);
+    expect(result.every((d) => d.value === null)).toBe(true);
+  });
+
+  it("picks latest sample when multiple per day", () => {
+    const samples = [
+      { date: new Date("2026-03-15T08:00:00Z"), value: 75.0 },
+      { date: new Date("2026-03-15T20:00:00Z"), value: 75.5 }, // latest
+    ];
+    const result = pickLatestPerDay(samples, new Date(2026, 2, 15));
+    expect(result[6].value).toBe(75.5);
+  });
+
+  it("handles missing days", () => {
+    const samples = [
+      { date: new Date("2026-03-15T08:00:00Z"), value: 75.0 },
+      { date: new Date("2026-03-12T08:00:00Z"), value: 74.5 },
+    ];
+    const result = pickLatestPerDay(samples, new Date(2026, 2, 15));
+    expect(result[6].value).toBe(75.0); // Mar 15
+    expect(result[3].value).toBe(74.5); // Mar 12
+    expect(result[4].value).toBeNull(); // Mar 13 — gap
+    expect(result[5].value).toBeNull(); // Mar 14 — gap
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: FAIL
+
+- [ ] **Step 3: Implement both functions**
+
+Add to `lib/weekly.ts`:
+
+```typescript
+import type { MindfulSession } from "./health";
+
+/**
+ * Aggregate mindful sessions into daily minutes. No overlap merge.
+ * Clamps negative durations to zero.
+ */
+export function aggregateMeditation(
+  sessions: MindfulSession[],
+  endDate: Date,
+): DailyValue[] {
+  const result: DailyValue[] = [];
+  const buckets = new Map<string, MindfulSession[]>();
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    const key = formatDateKey(d);
+    result.push({ date: key, value: null });
+    buckets.set(key, []);
+  }
+
+  for (const session of sessions) {
+    const key = formatDateKey(new Date(session.startDate));
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.push(session);
+    }
+  }
+
+  for (const day of result) {
+    const bucket = buckets.get(day.date)!;
+    if (bucket.length > 0) {
+      const totalMs = bucket.reduce((acc, s) => {
+        const start = new Date(s.startDate).getTime();
+        const end = new Date(s.endDate).getTime();
+        return acc + Math.max(0, end - start);
+      }, 0);
+      day.value = Math.round((totalMs / (1000 * 60)) * 10) / 10;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Pick the latest sample per day (for weight).
+ * Samples should have { date: Date, value: number }.
+ */
+export function pickLatestPerDay(
+  samples: { date: Date; value: number }[],
+  endDate: Date,
+): DailyValue[] {
+  const result: DailyValue[] = [];
+  const buckets = new Map<string, { date: Date; value: number }[]>();
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    const key = formatDateKey(d);
+    result.push({ date: key, value: null });
+    buckets.set(key, []);
+  }
+
+  for (const sample of samples) {
+    const key = formatDateKey(sample.date);
+    const bucket = buckets.get(key);
+    if (bucket) {
+      bucket.push(sample);
+    }
+  }
+
+  for (const day of result) {
+    const bucket = buckets.get(day.date)!;
+    if (bucket.length > 0) {
+      // Sort by date descending, pick first (latest)
+      bucket.sort((a, b) => b.date.getTime() - a.date.getTime());
+      day.value = Math.round(bucket[0].value * 100) / 100;
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/weekly.test.ts --verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/weekly.ts __tests__/weekly.test.ts
+git commit -m "feat: add aggregateMeditation and pickLatestPerDay"
+```
+
+---
+
+### Task 7: Run full test suite
+
+- [ ] **Step 1: Run all tests**
+
+Run: `npx jest --verbose`
+Expected: All existing tests PASS, all new weekly tests PASS
+
+- [ ] **Step 2: Fix any failures if needed**
+
+---
+
+## Chunk 2: Chart Components
+
+### Task 8: `BarChart` component
+
+**Files:**
+- Create: `components/BarChart.tsx`
+
+This is a pure React Native component. No HealthKit. Takes `DailyValue[]` and an accent color, renders 7 vertical bars.
+
+- [ ] **Step 1: Create `components/` directory and `BarChart.tsx`**
+
+```typescript
+// components/BarChart.tsx
+import { View, Text, StyleSheet } from "react-native";
+import { formatDateKey, type DailyValue } from "../lib/weekly";
+
+type BarChartProps = {
+  data: DailyValue[];
+  color: string;
+  unit: string;
+};
+
+const CHART_HEIGHT = 200;
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function getDayLabel(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  return DAY_LABELS[d.getUTCDay() === 0 ? 6 : d.getUTCDay() - 1];
+}
+
+export default function BarChart({ data, color, unit }: BarChartProps) {
+  const maxValue = Math.max(...data.map((d) => d.value ?? 0), 1);
+  const today = formatDateKey(new Date());
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.barsRow}>
+        {data.map((day) => {
+          const height =
+            day.value != null ? (day.value / maxValue) * CHART_HEIGHT : 0;
+          const isToday = day.date === today;
+          const barColor = isToday ? color : color + "4D"; // 30% opacity
+
+          return (
+            <View key={day.date} style={styles.barColumn}>
+              <View style={styles.barWrapper}>
+                {day.value != null ? (
+                  <View
+                    style={[
+                      styles.bar,
+                      {
+                        height,
+                        backgroundColor: barColor,
+                      },
+                    ]}
+                  />
+                ) : (
+                  <View style={styles.noData} />
+                )}
+              </View>
+              <Text style={styles.dayLabel}>{getDayLabel(day.date)}</Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: CHART_HEIGHT + 30,
+    paddingHorizontal: 8,
+  },
+  barsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    height: CHART_HEIGHT,
+  },
+  barColumn: {
+    flex: 1,
+    alignItems: "center",
+  },
+  barWrapper: {
+    flex: 1,
+    justifyContent: "flex-end",
+    width: "100%",
+    paddingHorizontal: 4,
+  },
+  bar: {
+    width: "100%",
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+    minHeight: 4,
+  },
+  noData: {
+    height: 2,
+    width: "60%",
+    backgroundColor: "#333",
+    borderRadius: 1,
+    alignSelf: "center",
+  },
+  dayLabel: {
+    fontSize: 11,
+    color: "#666",
+    marginTop: 6,
+  },
+});
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/BarChart.tsx
+git commit -m "feat: add BarChart component for 7-day bar visualization"
+```
+
+---
+
+### Task 9: `LineChart` component
+
+**Files:**
+- Create: `components/LineChart.tsx`
+
+Renders dots connected by lines. Supports both `DailyValue[]` (weight) and `HeartRateDaily[]` (heart rate with min/max range band).
+
+- [ ] **Step 1: Create `components/LineChart.tsx`**
+
+```typescript
+// components/LineChart.tsx
+import { View, Text, StyleSheet } from "react-native";
+import { formatDateKey, type DailyValue, type HeartRateDaily } from "../lib/weekly";
+
+type LineChartProps = {
+  data: DailyValue[] | HeartRateDaily[];
+  color: string;
+  unit: string;
+};
+
+const CHART_HEIGHT = 200;
+const DOT_SIZE = 8;
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function getDayLabel(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  return DAY_LABELS[d.getUTCDay() === 0 ? 6 : d.getUTCDay() - 1];
+}
+
+function isHeartRateData(data: (DailyValue | HeartRateDaily)[]): data is HeartRateDaily[] {
+  return data.length > 0 && "avg" in data[0];
+}
+
+export default function LineChart({ data, color, unit }: LineChartProps) {
+  const isHR = isHeartRateData(data);
+
+  // Get all values for computing range
+  const allValues: number[] = [];
+  for (const d of data) {
+    if (isHR) {
+      const hr = d as HeartRateDaily;
+      if (hr.min != null) allValues.push(hr.min);
+      if (hr.max != null) allValues.push(hr.max);
+      if (hr.avg != null) allValues.push(hr.avg);
+    } else {
+      const dv = d as DailyValue;
+      if (dv.value != null) allValues.push(dv.value);
+    }
+  }
+
+  if (allValues.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText}>No data</Text>
+        </View>
+      </View>
+    );
+  }
+
+  const minVal = Math.min(...allValues);
+  const maxVal = Math.max(...allValues);
+  const range = maxVal - minVal || 1;
+  const padding = range * 0.1;
+  const effectiveMin = minVal - padding;
+  const effectiveRange = range + padding * 2;
+
+  function yPos(val: number): number {
+    return CHART_HEIGHT - ((val - effectiveMin) / effectiveRange) * CHART_HEIGHT;
+  }
+
+  const today = formatDateKey(new Date());
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.chartArea}>
+        {/* Heart rate range bands */}
+        {isHR &&
+          (data as HeartRateDaily[]).map((d, i) => {
+            if (d.min == null || d.max == null) return null;
+            const top = yPos(d.max);
+            const bottom = yPos(d.min);
+            const left = `${(i / (data.length - 1 || 1)) * 100}%`;
+            return (
+              <View
+                key={`range-${d.date}`}
+                style={[
+                  styles.rangeBand,
+                  {
+                    top,
+                    height: bottom - top,
+                    left,
+                    backgroundColor: color + "26", // 15% opacity
+                  },
+                ]}
+              />
+            );
+          })}
+
+        {/* Dots */}
+        {data.map((d, i) => {
+          const val = isHR ? (d as HeartRateDaily).avg : (d as DailyValue).value;
+          if (val == null) return null;
+          const top = yPos(val) - DOT_SIZE / 2;
+          const left = `${(i / (data.length - 1 || 1)) * 100}%`;
+          const isToday = d.date === today;
+
+          return (
+            <View
+              key={`dot-${d.date}`}
+              style={[
+                styles.dot,
+                {
+                  top,
+                  left,
+                  backgroundColor: isToday ? color : color + "99",
+                  borderColor: isToday ? "#fff" : "transparent",
+                },
+              ]}
+            />
+          );
+        })}
+
+        {/* Note: Connecting lines between dots are omitted for simplicity.
+            The dots + range bands convey the trend effectively. */}
+      </View>
+
+      {/* Day labels */}
+      <View style={styles.labelsRow}>
+        {data.map((d) => (
+          <View key={`label-${d.date}`} style={styles.labelColumn}>
+            <Text style={styles.dayLabel}>{getDayLabel(d.date)}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: CHART_HEIGHT + 30,
+    paddingHorizontal: 8,
+  },
+  chartArea: {
+    height: CHART_HEIGHT,
+    position: "relative",
+  },
+  emptyContainer: {
+    height: CHART_HEIGHT,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  emptyText: {
+    color: "#555",
+    fontSize: 14,
+  },
+  rangeBand: {
+    position: "absolute",
+    width: 20,
+    borderRadius: 4,
+    marginLeft: -10,
+  },
+  dot: {
+    position: "absolute",
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    marginLeft: -DOT_SIZE / 2,
+    borderWidth: 1.5,
+  },
+  labelsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 6,
+  },
+  labelColumn: {
+    flex: 1,
+    alignItems: "center",
+  },
+  dayLabel: {
+    fontSize: 11,
+    color: "#666",
+  },
+});
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/LineChart.tsx
+git commit -m "feat: add LineChart component for heart rate and weight"
+```
+
+---
+
+## Chunk 3: MetricDetailSheet Component
+
+### Task 10: `MetricDetailSheet` component
+
+**Files:**
+- Create: `components/MetricDetailSheet.tsx`
+
+This is the full-screen slide-up sheet with animation, PanResponder, header, chart, average line, and daily breakdown.
+
+- [ ] **Step 1: Create `components/MetricDetailSheet.tsx`**
+
+```typescript
+// components/MetricDetailSheet.tsx
+import { useEffect, useRef } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Animated,
+  Dimensions,
+  Easing,
+  PanResponder,
+  ScrollView,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  ActivityIndicator,
+} from "react-native";
+import {
+  METRIC_CONFIG,
+  computeAverage,
+  type MetricKey,
+  type DailyValue,
+  type HeartRateDaily,
+} from "../lib/weekly";
+import { formatNumber } from "../lib/summary";
+import BarChart from "./BarChart";
+import LineChart from "./LineChart";
+
+type MetricDetailSheetProps = {
+  metricKey: MetricKey;
+  currentValue: string;
+  currentSublabel: string;
+  data: DailyValue[] | HeartRateDaily[] | null; // null = loading
+  error: string | null;
+  onClose: () => void;
+};
+
+const { height: SCREEN_HEIGHT } = Dimensions.get("window");
+
+function formatDailyValue(
+  day: DailyValue | HeartRateDaily,
+  unit: string,
+): string {
+  if ("avg" in day) {
+    const hr = day as HeartRateDaily;
+    if (hr.avg == null) return "\u2014";
+    return `${hr.avg} avg (${hr.min}\u2013${hr.max})`;
+  }
+  const dv = day as DailyValue;
+  if (dv.value == null) return "\u2014";
+  if (unit === "steps" || unit === "kcal") return formatNumber(dv.value);
+  return `${dv.value}`;
+}
+
+function formatDayRow(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00Z");
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  ];
+  return `${days[d.getUTCDay()]}, ${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+export default function MetricDetailSheet({
+  metricKey,
+  currentValue,
+  currentSublabel,
+  data,
+  error,
+  onClose,
+}: MetricDetailSheetProps) {
+  const config = METRIC_CONFIG[metricKey];
+  const slideAnim = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+
+  // Slide up on mount
+  useEffect(() => {
+    Animated.timing(slideAnim, {
+      toValue: 0,
+      duration: 300,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [slideAnim]);
+
+  function dismiss() {
+    Animated.timing(slideAnim, {
+      toValue: SCREEN_HEIGHT,
+      duration: 250,
+      easing: Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    }).start(() => onClose());
+  }
+
+  // PanResponder for swipe-to-dismiss on header+chart
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_, gestureState) =>
+        gestureState.dy > 10,
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) {
+          slideAnim.setValue(gestureState.dy);
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 100) {
+          dismiss();
+        } else {
+          Animated.timing(slideAnim, {
+            toValue: 0,
+            duration: 200,
+            useNativeDriver: true,
+          }).start();
+        }
+      },
+    }),
+  ).current;
+
+  const overlayOpacity = slideAnim.interpolate({
+    inputRange: [0, SCREEN_HEIGHT],
+    outputRange: [0.6, 0],
+    extrapolate: "clamp",
+  });
+
+  // Compute average
+  let avgText: string | null = null;
+  if (data) {
+    if (config.chartType === "line" && "avg" in (data[0] || {})) {
+      // Heart rate: average of avgs
+      const hrData = data as HeartRateDaily[];
+      const asDailyValues: DailyValue[] = hrData.map((d) => ({
+        date: d.date,
+        value: d.avg,
+      }));
+      const avg = computeAverage(asDailyValues);
+      if (avg != null) avgText = `Avg: ${avg} ${config.unit}/day`;
+    } else {
+      const avg = computeAverage(data as DailyValue[]);
+      if (avg != null) {
+        const formatted =
+          config.unit === "steps" || config.unit === "kcal"
+            ? formatNumber(Math.round(avg))
+            : `${avg}`;
+        avgText = `Avg: ${formatted} ${config.unit}/day`;
+      }
+    }
+  }
+
+  // Daily breakdown (reversed: most recent first)
+  const reversedData = data ? [...data].reverse() : [];
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      {/* Overlay — blocks taps on underlying UI */}
+      <TouchableWithoutFeedback onPress={dismiss}>
+        <Animated.View
+          style={[styles.overlay, { opacity: overlayOpacity }]}
+        />
+      </TouchableWithoutFeedback>
+
+      {/* Sheet */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          { transform: [{ translateY: slideAnim }] },
+        ]}
+      >
+        {/* Header + Chart zone (PanResponder) */}
+        <View {...panResponder.panHandlers}>
+          {/* Drag handle */}
+          <View style={styles.dragHandleContainer}>
+            <View style={styles.dragHandle} />
+          </View>
+
+          {/* Header */}
+          <View style={styles.header}>
+            <View style={styles.headerLeft}>
+              <Text style={[styles.metricName, { color: config.color }]}>
+                {config.label}
+              </Text>
+            </View>
+            <TouchableOpacity onPress={dismiss} style={styles.closeButton}>
+              <Text style={styles.closeText}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          <Text style={styles.currentValue}>{currentValue}</Text>
+          <Text style={styles.sublabel}>{currentSublabel}</Text>
+
+          {/* Chart */}
+          <View style={styles.chartContainer}>
+            {error ? (
+              <View style={styles.errorContainer}>
+                <Text style={styles.errorText}>{error}</Text>
+              </View>
+            ) : !data ? (
+              <View style={styles.loadingContainer}>
+                <ActivityIndicator size="large" color={config.color} />
+              </View>
+            ) : config.chartType === "bar" ? (
+              <BarChart
+                data={data as DailyValue[]}
+                color={config.color}
+                unit={config.unit}
+              />
+            ) : (
+              <LineChart data={data} color={config.color} unit={config.unit} />
+            )}
+          </View>
+
+          {/* Average */}
+          {avgText && (
+            <Text style={[styles.avgText, { color: config.color }]}>
+              {avgText}
+            </Text>
+          )}
+        </View>
+
+        {/* Daily Breakdown (separate ScrollView) */}
+        <ScrollView style={styles.breakdownScroll}>
+          <View style={styles.breakdownContainer}>
+            {reversedData.map((day, i) => (
+              <View
+                key={day.date}
+                style={[
+                  styles.breakdownRow,
+                  i < reversedData.length - 1 && styles.breakdownDivider,
+                ]}
+              >
+                <Text style={styles.breakdownDay}>
+                  {formatDayRow(day.date)}
+                </Text>
+                <Text
+                  style={[
+                    styles.breakdownValue,
+                    ("value" in day ? day.value : (day as HeartRateDaily).avg) ==
+                      null && styles.breakdownValueNull,
+                  ]}
+                >
+                  {formatDailyValue(day, config.unit)} {config.unit !== "steps" && config.unit !== "kcal" ? config.unit : ""}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </ScrollView>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "#000",
+  },
+  sheet: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "#111828",
+  },
+  dragHandleContainer: {
+    alignItems: "center",
+    paddingTop: 60,
+    paddingBottom: 8,
+  },
+  dragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "#444",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 20,
+  },
+  headerLeft: {
+    flex: 1,
+  },
+  metricName: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  closeButton: {
+    padding: 8,
+  },
+  closeText: {
+    fontSize: 20,
+    color: "#888",
+  },
+  currentValue: {
+    fontSize: 36,
+    fontWeight: "bold",
+    color: "#e0e0e0",
+    paddingHorizontal: 20,
+    marginTop: 4,
+  },
+  sublabel: {
+    fontSize: 13,
+    color: "#888",
+    paddingHorizontal: 20,
+    marginBottom: 20,
+  },
+  chartContainer: {
+    paddingHorizontal: 12,
+  },
+  loadingContainer: {
+    height: 200,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  errorContainer: {
+    height: 200,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 20,
+  },
+  errorText: {
+    color: "#ff6b6b",
+    fontSize: 14,
+    textAlign: "center",
+  },
+  avgText: {
+    fontSize: 14,
+    fontWeight: "600",
+    textAlign: "center",
+    marginTop: 12,
+    marginBottom: 16,
+  },
+  breakdownScroll: {
+    flex: 1,
+  },
+  breakdownContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
+  breakdownRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 14,
+  },
+  breakdownDivider: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#222",
+  },
+  breakdownDay: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#e0e0e0",
+  },
+  breakdownValue: {
+    fontSize: 15,
+    color: "#aaa",
+  },
+  breakdownValueNull: {
+    color: "#555",
+  },
+});
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/MetricDetailSheet.tsx
+git commit -m "feat: add MetricDetailSheet slide-up component"
+```
+
+---
+
+## Chunk 4: App.tsx Integration
+
+### Task 11: Make MetricCard tappable
+
+**Files:**
+- Modify: `App.tsx`
+
+- [ ] **Step 1: Import MetricKey type and add state**
+
+At the top of `App.tsx`, add:
+
+```typescript
+import type { MetricKey } from "./lib/weekly";
+```
+
+Inside the App component, after existing state declarations, add:
+
+```typescript
+const [selectedMetric, setSelectedMetric] = useState<MetricKey | null>(null);
+```
+
+- [ ] **Step 2: Update MetricCardProps and MetricCard component**
+
+Change the `MetricCardProps` type to add `metricKey` and `onPress`:
+
+```typescript
+type MetricCardProps = {
+  metricKey: MetricKey;
+  label: string;
+  value: string;
+  sublabel: string;
+  fullWidth?: boolean;
+  onPress: (key: MetricKey) => void;
+};
+```
+
+Wrap `MetricCard` content in `TouchableOpacity`:
+
+```typescript
+function MetricCard({ metricKey, label, value, sublabel, fullWidth, onPress }: MetricCardProps) {
+  const isNull = value === "\u2014";
+  return (
+    <TouchableOpacity
+      style={[styles.metricCard, fullWidth && styles.metricCardFull]}
+      onPress={() => onPress(metricKey)}
+      activeOpacity={0.7}
+    >
+      <Text style={styles.metricLabel}>{label}</Text>
+      <Text style={[styles.metricValue, isNull && styles.metricValueNull]}>
+        {value}
+      </Text>
+      <Text style={styles.metricSublabel}>{sublabel}</Text>
+    </TouchableOpacity>
+  );
+}
+```
+
+- [ ] **Step 3: Update the metrics array to include metricKey**
+
+Change the metrics array type and values. Replace the `MetricCardProps[]` type with an explicit type that includes `metricKey`:
+
+```typescript
+const metrics = snapshot
+  ? [
+      {
+        metricKey: "steps" as MetricKey,
+        label: "Steps",
+        value: h?.steps != null ? formatNumber(h.steps) : "\u2014",
+        sublabel: "today",
+      },
+      {
+        metricKey: "heartRate" as MetricKey,
+        label: "Heart Rate",
+        value: h?.heartRate != null ? `${h.heartRate} bpm` : "\u2014",
+        sublabel: "latest",
+      },
+      {
+        metricKey: "sleep" as MetricKey,
+        label: "Sleep",
+        value: h?.sleepHours != null ? `${h.sleepHours} hrs` : "\u2014",
+        sublabel:
+          h?.bedtime && h?.wakeTime
+            ? `${h.bedtime} \u2013 ${h.wakeTime}`
+            : "last night",
+      },
+      {
+        metricKey: "activeEnergy" as MetricKey,
+        label: "Active Energy",
+        value: h?.activeEnergy != null ? `${formatNumber(h.activeEnergy)} kcal` : "\u2014",
+        sublabel: "today",
+      },
+      {
+        metricKey: "walkingDistance" as MetricKey,
+        label: "Walking Distance",
+        value: h?.walkingDistance != null ? `${h.walkingDistance} km` : "\u2014",
+        sublabel: "today",
+      },
+      {
+        metricKey: "weight" as MetricKey,
+        label: "Weight",
+        value: h?.weight != null ? `${h.weight} kg` : "\u2014",
+        sublabel:
+          h?.weightDaysLast7 != null
+            ? `${h.weightDaysLast7}/7 days weighed`
+            : "latest",
+      },
+      {
+        metricKey: "meditation" as MetricKey,
+        label: "Meditation",
+        value: h?.meditationMinutes != null ? `${h.meditationMinutes} min` : "\u2014",
+        sublabel: "today",
+      },
+    ]
+  : [];
+```
+
+- [ ] **Step 4: Update MetricCard rendering to pass new props**
+
+In the JSX, add `metricKey` and `onPress` (we'll wire `onPress` to a placeholder for now):
+
+```tsx
+{metrics.map((m, i) => (
+  <MetricCard
+    key={m.label}
+    metricKey={m.metricKey}
+    label={m.label}
+    value={m.value}
+    sublabel={m.sublabel}
+    fullWidth={metrics.length % 2 === 1 && i === metrics.length - 1}
+    onPress={(key) => setSelectedMetric(key)}
+  />
+))}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add App.tsx
+git commit -m "feat: make MetricCard tappable with metricKey prop"
+```
+
+---
+
+### Task 12: Add weekly data fetching and sheet state
+
+**Files:**
+- Modify: `App.tsx`
+
+- [ ] **Step 1: Add new state variables**
+
+After the existing state declarations in the App component, add:
+
+```typescript
+const [weeklyCache, setWeeklyCache] = useState<
+  Partial<Record<MetricKey, DailyValue[] | HeartRateDaily[]>>
+>({});
+const [weeklyLoading, setWeeklyLoading] = useState(false);
+const [weeklyError, setWeeklyError] = useState<string | null>(null);
+```
+
+- [ ] **Step 2: Add imports for weekly types and HealthKit queries**
+
+Add to the top of `App.tsx`:
+
+```typescript
+import {
+  type MetricKey,
+  type DailyValue,
+  type HeartRateDaily,
+  aggregateHeartRate,
+  aggregateSleep,
+  aggregateMeditation,
+  pickLatestPerDay,
+} from "./lib/weekly";
+import MetricDetailSheet from "./components/MetricDetailSheet";
+```
+
+- [ ] **Step 3: Add `grabWeeklyData` function**
+
+Inside the App component, after `grabLocation`:
+
+```typescript
+async function grabWeeklyData(metric: MetricKey): Promise<DailyValue[] | HeartRateDaily[]> {
+  const now = new Date();
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const dateFilter = {
+    date: { startDate: sevenDaysAgo, endDate: now },
+  };
+
+  switch (metric) {
+    case "steps":
+    case "activeEnergy":
+    case "walkingDistance": {
+      const identifier =
+        metric === "steps"
+          ? QTI.stepCount
+          : metric === "activeEnergy"
+            ? QTI.activeEnergy
+            : QTI.distance;
+      // Query all 7 days in parallel (local time boundaries, matching grabHealthData)
+      const dayPromises = Array.from({ length: 7 }, (_, idx) => {
+        const i = 6 - idx;
+        const dayStart = new Date(now);
+        dayStart.setDate(dayStart.getDate() - i);
+        dayStart.setHours(0, 0, 0, 0);
+        const dayEnd = new Date(dayStart);
+        dayEnd.setHours(23, 59, 59, 999);
+        const dateKey = `${dayStart.getFullYear()}-${String(dayStart.getMonth() + 1).padStart(2, "0")}-${String(dayStart.getDate()).padStart(2, "0")}`;
+        return HealthKit.queryStatisticsForQuantity(
+          identifier,
+          ["cumulativeSum"],
+          { filter: { date: { startDate: dayStart, endDate: dayEnd } } },
+        )
+          .then((result) => ({
+            date: dateKey,
+            value: result?.sumQuantity?.quantity != null
+              ? Math.round(result.sumQuantity.quantity * 100) / 100
+              : null,
+          }))
+          .catch(() => ({ date: dateKey, value: null }));
+      });
+      return Promise.all(dayPromises);
+    }
+
+    case "heartRate": {
+      const samples = await HealthKit.queryQuantitySamples(QTI.heartRate, {
+        limit: 0,
+        filter: dateFilter,
+      });
+      const mapped = samples.map((s: any) => ({
+        date: new Date(s.startDate),
+        value: s.quantity,
+      }));
+      return aggregateHeartRate(mapped, now);
+    }
+
+    case "sleep": {
+      const samples = await HealthKit.queryCategorySamples(CTI.sleep, {
+        limit: 0,
+        filter: dateFilter,
+      });
+      return aggregateSleep(samples, now);
+    }
+
+    case "weight": {
+      const samples = await HealthKit.queryQuantitySamples(QTI.bodyMass, {
+        limit: 0,
+        filter: dateFilter,
+      });
+      const mapped = samples.map((s: any) => ({
+        date: new Date(s.startDate),
+        value: s.quantity,
+      }));
+      return pickLatestPerDay(mapped, now);
+    }
+
+    case "meditation": {
+      const sessions = await HealthKit.queryCategorySamples(
+        CTI.mindfulSession,
+        { limit: 0, filter: dateFilter },
+      );
+      return aggregateMeditation(sessions, now);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Add `handleMetricPress` function**
+
+```typescript
+async function handleMetricPress(key: MetricKey) {
+  setSelectedMetric(key);
+  setWeeklyError(null);
+
+  if (weeklyCache[key]) return; // Already cached
+
+  setWeeklyLoading(true);
+  try {
+    const data = await grabWeeklyData(key);
+    setWeeklyCache((prev) => ({ ...prev, [key]: data }));
+  } catch (e: any) {
+    setWeeklyError(e.message ?? "Failed to load weekly data");
+  } finally {
+    setWeeklyLoading(false);
+  }
+}
+```
+
+- [ ] **Step 5: Clear weekly cache when grabbing new context**
+
+In `grabContext()`, after `setLoading(true)` and `setError(null)`, add:
+
+```typescript
+setWeeklyCache({});
+setWeeklyError(null);
+```
+
+- [ ] **Step 6: Wire up MetricCard onPress to handleMetricPress**
+
+Update the MetricCard rendering (if not already done in Task 11):
+
+```tsx
+onPress={handleMetricPress}
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add App.tsx
+git commit -m "feat: add weekly data fetching with per-metric caching"
+```
+
+---
+
+### Task 13: Render MetricDetailSheet
+
+**Files:**
+- Modify: `App.tsx`
+
+- [ ] **Step 1: Add MetricDetailSheet rendering**
+
+Just before the closing `</View>` of the root container (before `<View style={styles.buttons}>`... actually, after the entire tree but inside the root `<View style={styles.container}>`), add:
+
+```tsx
+{selectedMetric && (
+  <MetricDetailSheet
+    metricKey={selectedMetric}
+    currentValue={
+      metrics.find((m) => m.metricKey === selectedMetric)?.value ?? "\u2014"
+    }
+    currentSublabel={
+      metrics.find((m) => m.metricKey === selectedMetric)?.sublabel ?? ""
+    }
+    data={weeklyCache[selectedMetric] ?? null}
+    error={weeklyError}
+    onClose={() => {
+      setSelectedMetric(null);
+      setWeeklyError(null);
+    }}
+  />
+)}
+```
+
+Place this after the `</View>` of `styles.buttons` and before the final `</View>` closing `styles.container`.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Run all tests**
+
+Run: `npx jest --verbose`
+Expected: All tests pass (existing + new weekly tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add App.tsx
+git commit -m "feat: render MetricDetailSheet on card tap"
+```
+
+---
+
+## Chunk 5: Final Verification
+
+### Task 14: Full test suite + type check
+
+- [ ] **Step 1: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 3: Review all new/modified files for consistency**
+
+Files to review:
+- `lib/weekly.ts` — types, pure functions
+- `__tests__/weekly.test.ts` — test coverage
+- `components/BarChart.tsx` — bar chart rendering
+- `components/LineChart.tsx` — line chart rendering
+- `components/MetricDetailSheet.tsx` — sheet with animation
+- `App.tsx` — integration, state, HealthKit queries
+
+- [ ] **Step 4: Final commit if any cleanup needed**

--- a/docs/superpowers/specs/2026-03-15-7-day-metric-detail-design.md
+++ b/docs/superpowers/specs/2026-03-15-7-day-metric-detail-design.md
@@ -1,0 +1,270 @@
+# 7-Day Metric Detail View — Design Spec
+
+## Overview
+
+Add a tap-to-drill-down feature to the Context Grabber dashboard. When a user taps any metric card (steps, heart rate, sleep, etc.), a full-screen sheet slides up showing a 7-day chart and daily breakdown for that metric.
+
+## Goals
+
+- Let users see trailing 7-day trends for every health metric
+- Keep the app dependency-light (no navigation library, no charting library)
+- Maintain the existing dark aesthetic while creating a "deep dive" feel
+
+## Non-Goals
+
+- No navigation library (single drill-down doesn't justify the dependency)
+- No charting library (simple 7-day visualizations are achievable with RN Views)
+- No changes to the existing "Grab Context" or share flow
+- No persistent storage of weekly data
+
+---
+
+## Data Layer
+
+### MetricKey Type and Configuration
+
+```typescript
+type MetricKey = "steps" | "heartRate" | "sleep" | "activeEnergy" | "walkingDistance" | "weight" | "meditation";
+
+type ChartType = "bar" | "line";
+
+type MetricConfig = {
+  label: string;
+  unit: string;
+  color: string;
+  chartType: ChartType;
+  sublabel: string;
+};
+
+const METRIC_CONFIG: Record<MetricKey, MetricConfig> = {
+  steps:           { label: "Steps",            unit: "steps",  color: "#4cc9f0", chartType: "bar",  sublabel: "today" },
+  heartRate:       { label: "Heart Rate",       unit: "bpm",    color: "#f72585", chartType: "line", sublabel: "latest" },
+  sleep:           { label: "Sleep",            unit: "hrs",    color: "#7b2cbf", chartType: "bar",  sublabel: "last night" },
+  activeEnergy:    { label: "Active Energy",    unit: "kcal",   color: "#ff9e00", chartType: "bar",  sublabel: "today" },
+  walkingDistance:  { label: "Walking Distance", unit: "km",     color: "#06d6a0", chartType: "bar",  sublabel: "today" },
+  weight:          { label: "Weight",           unit: "kg",     color: "#4895ef", chartType: "line", sublabel: "latest" },
+  meditation:      { label: "Meditation",       unit: "min",    color: "#e0aaff", chartType: "bar",  sublabel: "today" },
+};
+```
+
+### DailyValue Types
+
+```typescript
+// date format: "YYYY-MM-DD" (e.g., "2026-03-15")
+type DailyValue = { date: string; value: number | null };
+
+type HeartRateDaily = {
+  date: string;
+  avg: number | null;
+  min: number | null;
+  max: number | null;
+};
+```
+
+Note: The `WeeklyMetricData` aggregate type is not needed since data is fetched per-metric. The cache state is typed as:
+
+```typescript
+type WeeklyCache = Partial<Record<MetricKey, DailyValue[] | HeartRateDaily[]>>;
+```
+
+### New HealthKit Queries
+
+A new function in `App.tsx`:
+
+```typescript
+async function grabWeeklyData(metric: MetricKey): Promise<DailyValue[] | HeartRateDaily[]>
+```
+
+This dispatches to the appropriate HealthKit query based on metric key:
+
+| Metric | HealthKit Method | Identifier | Daily Aggregation |
+|--------|-----------------|------------|-------------------|
+| Steps | `queryStatisticsForQuantity` per day | `HKQuantityTypeIdentifierStepCount` | Sum |
+| Heart Rate | `queryQuantitySamples` for 7 days | `HKQuantityTypeIdentifierHeartRate` | Avg / Min / Max per day |
+| Sleep | `queryCategorySamples` for 7 nights | `HKCategoryTypeIdentifierSleepAnalysis` | Hours per night (overlap-merged) |
+| Active Energy | `queryStatisticsForQuantity` per day | `HKQuantityTypeIdentifierActiveEnergyBurned` | Sum |
+| Walking Distance | `queryStatisticsForQuantity` per day | `HKQuantityTypeIdentifierDistanceWalkingRunning` | Sum |
+| Weight | `queryQuantitySamples` for 7 days | `HKQuantityTypeIdentifierBodyMass` | Latest value per day |
+| Meditation | `queryCategorySamples` for 7 days | `HKCategoryTypeIdentifierMindfulSession` | Sum minutes per day (no overlap merge — matches existing behavior) |
+
+**Error handling**: Wrapped in try/catch. On failure, the sheet shows an error message within the sheet (not a dismiss). HealthKit authorization is assumed already granted from the initial "Grab Context" — no re-request.
+
+### Fetching Strategy
+
+- **Lazy**: Weekly data is fetched only when the user taps a card, not during "Grab Context"
+- **Cached**: Results are stored in `weeklyCache` state (`WeeklyCache`) so re-tapping doesn't re-fetch
+- **Per-metric**: Only the tapped metric's data is fetched
+- **Cache invalidation**: Cache is cleared when a new "Grab Context" is performed (fresh snapshot = stale weekly cache)
+
+### New Pure Module: `lib/weekly.ts`
+
+Functions to bucket raw HealthKit samples into daily arrays:
+
+- `bucketByDay(samples, startDate, days)` — generic day-bucketing helper
+- `aggregateHeartRate(samples, startDate)` — buckets HR samples, computes avg/min/max per day → `HeartRateDaily[]`
+- `aggregateSleep(samples, startDate)` — applies overlap-merge per night (reuses logic from `lib/health.ts`), returns hours → `DailyValue[]`
+- `aggregateMeditation(sessions, startDate)` — sums minutes per day (no overlap merge) → `DailyValue[]`
+- `pickLatestPerDay(samples, startDate)` — for weight: picks latest sample per day → `DailyValue[]`
+- `computeAverage(dailyValues)` — 7-day average for the summary line
+
+All types (`DailyValue`, `HeartRateDaily`, `MetricKey`, `MetricConfig`, `METRIC_CONFIG`) are exported from `lib/weekly.ts`.
+
+All pure, all testable without HealthKit.
+
+---
+
+## Interaction & Animation
+
+### Making Cards Tappable
+
+- `MetricCard` gets a new `metricKey: MetricKey` prop and `onPress: (key: MetricKey) => void` prop
+- Wraps existing content in `TouchableOpacity`
+- Only tappable when a snapshot exists (cards aren't shown without one, so this is implicit)
+
+Updated `MetricCardProps`:
+
+```typescript
+type MetricCardProps = {
+  metricKey: MetricKey;
+  label: string;
+  value: string;
+  sublabel: string;
+  fullWidth?: boolean;
+  onPress: (key: MetricKey) => void;
+};
+```
+
+### Detail Sheet Lifecycle
+
+1. User taps card → `selectedMetric` state set to metric key
+2. Sheet renders, slide-up animation begins
+3. Semi-transparent overlay fades in behind the sheet
+4. If `weeklyCache[metricKey]` exists, render immediately; otherwise show loading spinner and fetch
+5. Chart + daily breakdown renders
+6. Dismiss: tap "X" button or swipe down
+7. Sheet slides down, overlay fades out, `selectedMetric` set to null
+
+### Animation Details
+
+- Single `Animated.Value` drives both animations via interpolation:
+  - Sheet `translateY`: `screenHeight → 0`
+  - Overlay `opacity`: `0 → 0.6` (interpolated from the same animated value)
+- `Animated.timing` with `useNativeDriver: true`
+- Duration: 300ms, easing: `Easing.out(Easing.cubic)`
+
+### Swipe-to-Dismiss
+
+- The header area (above the daily breakdown) has a `PanResponder`
+- The sheet follows the finger during downward swipe (gesture tracking via `translateY`)
+- On release: if swipe distance > 100px, animate to dismiss; otherwise snap back
+- Upward swipes are no-ops (clamped at 0)
+- The daily breakdown list uses a `ScrollView` that is **separate** from the PanResponder zone — the PanResponder is only on the header + chart area, avoiding gesture conflicts with the scrollable breakdown list
+
+---
+
+## Visual Design
+
+### Color Palette Per Metric
+
+Defined in `METRIC_CONFIG` above. Summary:
+
+| Metric | Accent Color | Hex |
+|--------|-------------|-----|
+| Steps | Cyan | `#4cc9f0` |
+| Heart Rate | Warm Pink | `#f72585` |
+| Sleep | Deep Purple | `#7b2cbf` |
+| Active Energy | Amber | `#ff9e00` |
+| Walking Distance | Mint Green | `#06d6a0` |
+| Weight | Soft Blue | `#4895ef` |
+| Meditation | Lavender | `#e0aaff` |
+
+### Sheet Layout (top to bottom)
+
+1. **Header bar** (inside PanResponder zone)
+   - Metric name (16px semibold, accent color) — left aligned
+   - Close "X" button — right aligned
+   - Current value (36px bold, white) below the name
+   - Sublabel below value (e.g., "today", "last night")
+
+2. **Chart area** (~200px tall, inside PanResponder zone)
+   - **Bar charts** for: Steps, Active Energy, Walking Distance, Sleep, Meditation
+     - 7 vertical bars, rounded tops, evenly spaced
+     - Bar height proportional to value vs week max
+     - Current day highlighted with accent color; other days use accent at 30% opacity
+     - Day labels (Mon, Tue...) below bars
+   - **Line charts** for: Heart Rate, Weight
+     - 7 dots connected by line, absolute-positioned Views
+     - Heart Rate: shaded min/max range band behind avg line
+     - Weight: dot-line with gaps for missing days
+
+3. **7-day average line**
+   - "Avg: 7,823 steps/day" in accent color
+   - Centered below the chart
+
+4. **Daily breakdown list** (inside ScrollView, separate from PanResponder)
+   - 7 rows, most recent at top
+   - Each row: day name + full date on left (e.g., "Mon, Mar 9"), value on right
+   - Subtle `#222` dividers between rows
+   - Null days show "—" in muted text
+   - Heart rate rows show "72 avg (58–91)" format
+
+### Sheet Background
+
+`#111828` — darker than main app surface (`#1a1a2e`) to create depth.
+
+### Typography
+
+| Element | Size | Weight | Color |
+|---------|------|--------|-------|
+| Metric name | 16px | Semibold | Accent color |
+| Current value | 36px | Bold | `#e0e0e0` |
+| Sublabel | 13px | Regular | `#888` |
+| Chart day labels | 11px | Regular | `#666` |
+| Average line | 14px | Semibold | Accent color |
+| Daily breakdown day | 15px | Semibold | `#e0e0e0` |
+| Daily breakdown value | 15px | Regular | `#aaa` |
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `lib/weekly.ts` | Types (`DailyValue`, `HeartRateDaily`, `MetricKey`, `MetricConfig`, `METRIC_CONFIG`), pure functions (bucketing, aggregation, averages) |
+| `__tests__/weekly.test.ts` | Tests for all weekly.ts functions |
+| `components/MetricDetailSheet.tsx` | Full-screen slide-up sheet with header, chart, breakdown, animations, PanResponder |
+| `components/BarChart.tsx` | Pure RN bar chart (takes `DailyValue[]` + accent color) |
+| `components/LineChart.tsx` | Pure RN line chart (takes `DailyValue[]` or `HeartRateDaily[]` + accent color) |
+
+Note: The `components/` directory is new. This is the first extraction of UI components out of `App.tsx`. `MetricCard` stays in `App.tsx` for now since it's small and tightly coupled to the metrics array.
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `App.tsx` | Add `metricKey` and `onPress` to MetricCard, add `selectedMetric` and `weeklyCache` state, add `grabWeeklyData()` function, render `MetricDetailSheet` conditionally, clear cache on new grab |
+
+### Unchanged
+
+- `lib/health.ts`, `lib/sleep.ts`, `lib/location.ts`, `lib/summary.ts` — no changes
+- Existing "Grab Context" flow (except clearing weekly cache)
+- Snapshot/share JSON behavior
+- All existing tests
+- No new npm dependencies
+
+---
+
+## Testing
+
+- `lib/weekly.ts` — fully tested with mock data:
+  - `bucketByDay`: normal case, gaps, empty input
+  - `aggregateHeartRate`: multiple readings per day, days with no data
+  - `aggregateSleep`: overlapping intervals, single source, no data
+  - `aggregateMeditation`: multiple sessions per day, zero-duration sessions
+  - `pickLatestPerDay`: multiple weights per day, missing days
+  - `computeAverage`: with nulls, all nulls, normal case
+- Chart components — take plain data arrays, visual testing not required
+- HealthKit queries — device-only, not unit tested (matches existing pattern)
+- Integration — manual testing on physical iPhone

--- a/lib/weekly.ts
+++ b/lib/weekly.ts
@@ -1,0 +1,268 @@
+/**
+ * Data layer for the 7-day metric detail feature.
+ * Pure functions — no device/HealthKit access, fully testable.
+ */
+
+import { calculateSleepHours, type SleepSample, type MindfulSession } from "./health";
+
+// ─── Types & Config ───────────────────────────────────────────────────────────
+
+export type MetricKey =
+  | "steps"
+  | "heartRate"
+  | "sleep"
+  | "activeEnergy"
+  | "walkingDistance"
+  | "weight"
+  | "meditation";
+
+export type ChartType = "bar" | "line" | "range";
+
+export type MetricConfig = {
+  label: string;
+  unit: string;
+  chartType: ChartType;
+  decimals: number;
+};
+
+export const METRIC_CONFIG: Record<MetricKey, MetricConfig> = {
+  steps: { label: "Steps", unit: "steps", chartType: "bar", decimals: 0 },
+  heartRate: { label: "Heart Rate", unit: "bpm", chartType: "range", decimals: 0 },
+  sleep: { label: "Sleep", unit: "hrs", chartType: "bar", decimals: 1 },
+  activeEnergy: { label: "Active Energy", unit: "kcal", chartType: "bar", decimals: 0 },
+  walkingDistance: { label: "Walking Distance", unit: "km", chartType: "bar", decimals: 2 },
+  weight: { label: "Weight", unit: "kg", chartType: "line", decimals: 1 },
+  meditation: { label: "Meditation", unit: "min", chartType: "bar", decimals: 0 },
+};
+
+/** A single-value day bucket (used by most metrics). */
+export type DailyValue = {
+  date: string; // "YYYY-MM-DD"
+  value: number | null;
+};
+
+/** Heart-rate day bucket with avg/min/max. */
+export type HeartRateDaily = {
+  date: string;
+  avg: number | null;
+  min: number | null;
+  max: number | null;
+};
+
+// ─── formatDateKey ────────────────────────────────────────────────────────────
+
+/**
+ * Format a Date as "YYYY-MM-DD" using LOCAL time (not UTC).
+ * Uses getFullYear / getMonth / getDate — NOT toISOString().
+ */
+export function formatDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// ─── bucketByDay ──────────────────────────────────────────────────────────────
+
+type HasStartDate = { startDate: Date | string };
+
+/**
+ * Generic day-bucketing: distributes samples into `days` buckets ending at
+ * `endDate` (inclusive). Buckets are keyed by local-time date ("YYYY-MM-DD").
+ * Days with no samples get `value: null`.
+ *
+ * @param samples   Array of objects with a `startDate` field.
+ * @param endDate   The last (most recent) day to include.
+ * @param days      Number of days in the window (7 means today + 6 prior days).
+ * @param aggregate Called with all samples for a bucket; return the aggregated
+ *                  value, or null if the bucket should be empty.
+ */
+export function bucketByDay<T extends HasStartDate>(
+  samples: T[],
+  endDate: Date,
+  days: number,
+  aggregate: (samples: T[]) => number | null,
+): DailyValue[] {
+  // Build the ordered list of date keys for the window.
+  const buckets: DailyValue[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    buckets.push({ date: formatDateKey(d), value: null });
+  }
+
+  // Build a set of valid keys for fast lookup.
+  const keySet = new Set(buckets.map((b) => b.date));
+
+  // Group samples by their local-time date key.
+  const grouped = new Map<string, T[]>();
+  for (const sample of samples) {
+    const key = formatDateKey(new Date(sample.startDate));
+    if (!keySet.has(key)) continue;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(sample);
+  }
+
+  // Aggregate each bucket.
+  for (const bucket of buckets) {
+    const daySamples = grouped.get(bucket.date);
+    if (daySamples && daySamples.length > 0) {
+      bucket.value = aggregate(daySamples);
+    }
+  }
+
+  return buckets;
+}
+
+// ─── computeAverage ───────────────────────────────────────────────────────────
+
+/**
+ * Average non-null values in a DailyValue array, rounded to 1 decimal.
+ * Returns null when there are no non-null values.
+ */
+export function computeAverage(values: DailyValue[]): number | null {
+  const nonNull = values.filter((v) => v.value !== null) as Array<DailyValue & { value: number }>;
+  if (nonNull.length === 0) return null;
+  const sum = nonNull.reduce((acc, v) => acc + v.value, 0);
+  return Math.round((sum / nonNull.length) * 10) / 10;
+}
+
+// ─── aggregateHeartRate ───────────────────────────────────────────────────────
+
+type HRSample = { startDate: Date | string; quantity: number };
+
+/**
+ * Compute daily avg/min/max heart rate over a `days`-day window ending at `endDate`.
+ */
+export function aggregateHeartRate(
+  samples: HRSample[],
+  endDate: Date,
+  days = 7,
+): HeartRateDaily[] {
+  // Build ordered bucket list.
+  const results: HeartRateDaily[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    results.push({ date: formatDateKey(d), avg: null, min: null, max: null });
+  }
+
+  const keySet = new Set(results.map((r) => r.date));
+
+  // Group samples by day.
+  const grouped = new Map<string, number[]>();
+  for (const sample of samples) {
+    const key = formatDateKey(new Date(sample.startDate));
+    if (!keySet.has(key)) continue;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(sample.quantity);
+  }
+
+  // Fill in avg/min/max.
+  for (const bucket of results) {
+    const vals = grouped.get(bucket.date);
+    if (!vals || vals.length === 0) continue;
+    const sum = vals.reduce((a, v) => a + v, 0);
+    bucket.avg = Math.round((sum / vals.length) * 10) / 10;
+    bucket.min = Math.min(...vals);
+    bucket.max = Math.max(...vals);
+  }
+
+  return results;
+}
+
+// ─── aggregateSleep ───────────────────────────────────────────────────────────
+
+/**
+ * Aggregate per-night sleep hours over a `days`-day window ending at `endDate`.
+ *
+ * Sleep is assigned to the LOCAL date of its `startDate`. All samples sharing
+ * the same start-date bucket are merged with `calculateSleepHours` to handle
+ * overlapping sources (Watch + iPhone).
+ */
+export function aggregateSleep(
+  samples: SleepSample[],
+  endDate: Date,
+  days = 7,
+): DailyValue[] {
+  return bucketByDay<SleepSample>(
+    samples,
+    endDate,
+    days,
+    (daySamples) => calculateSleepHours(daySamples),
+  );
+}
+
+// ─── aggregateMeditation ─────────────────────────────────────────────────────
+
+/**
+ * Aggregate meditation minutes per day over a `days`-day window ending at `endDate`.
+ *
+ * Multiple sessions on the same day are summed. Negative durations are clamped to 0.
+ * Does NOT merge overlapping sessions (meditation sessions don't typically overlap).
+ */
+export function aggregateMeditation(
+  sessions: MindfulSession[],
+  endDate: Date,
+  days = 7,
+): DailyValue[] {
+  return bucketByDay<MindfulSession>(
+    sessions,
+    endDate,
+    days,
+    (daySessions) => {
+      const totalMs = daySessions.reduce((acc, s) => {
+        const start = new Date(s.startDate).getTime();
+        const end = new Date(s.endDate).getTime();
+        return acc + Math.max(0, end - start);
+      }, 0);
+      return Math.round((totalMs / (1000 * 60)) * 10) / 10;
+    },
+  );
+}
+
+// ─── pickLatestPerDay ─────────────────────────────────────────────────────────
+
+type QuantitySample = { startDate: Date | string; quantity: number };
+
+/**
+ * For weight: pick the latest reading per day in a `days`-day window ending
+ * at `endDate`. Values are rounded to 2 decimal places.
+ */
+export function pickLatestPerDay(
+  samples: QuantitySample[],
+  endDate: Date,
+  days = 7,
+): DailyValue[] {
+  // Build ordered bucket list.
+  const results: DailyValue[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(endDate);
+    d.setDate(d.getDate() - i);
+    results.push({ date: formatDateKey(d), value: null });
+  }
+
+  const keySet = new Set(results.map((r) => r.date));
+
+  // Group samples by day, keeping track of latest timestamp.
+  const latestByDay = new Map<string, { ts: number; quantity: number }>();
+  for (const sample of samples) {
+    const d = new Date(sample.startDate);
+    const key = formatDateKey(d);
+    if (!keySet.has(key)) continue;
+    const ts = d.getTime();
+    const existing = latestByDay.get(key);
+    if (!existing || ts > existing.ts) {
+      latestByDay.set(key, { ts, quantity: sample.quantity });
+    }
+  }
+
+  for (const bucket of results) {
+    const entry = latestByDay.get(bucket.date);
+    if (entry != null) {
+      bucket.value = Math.round(entry.quantity * 100) / 100;
+    }
+  }
+
+  return results;
+}

--- a/lib/weekly.ts
+++ b/lib/weekly.ts
@@ -16,23 +16,24 @@ export type MetricKey =
   | "weight"
   | "meditation";
 
-export type ChartType = "bar" | "line" | "range";
+export type ChartType = "bar" | "line";
 
 export type MetricConfig = {
   label: string;
   unit: string;
+  color: string;
   chartType: ChartType;
-  decimals: number;
+  sublabel: string;
 };
 
 export const METRIC_CONFIG: Record<MetricKey, MetricConfig> = {
-  steps: { label: "Steps", unit: "steps", chartType: "bar", decimals: 0 },
-  heartRate: { label: "Heart Rate", unit: "bpm", chartType: "range", decimals: 0 },
-  sleep: { label: "Sleep", unit: "hrs", chartType: "bar", decimals: 1 },
-  activeEnergy: { label: "Active Energy", unit: "kcal", chartType: "bar", decimals: 0 },
-  walkingDistance: { label: "Walking Distance", unit: "km", chartType: "bar", decimals: 2 },
-  weight: { label: "Weight", unit: "kg", chartType: "line", decimals: 1 },
-  meditation: { label: "Meditation", unit: "min", chartType: "bar", decimals: 0 },
+  steps: { label: "Steps", unit: "steps", color: "#4cc9f0", chartType: "bar", sublabel: "today" },
+  heartRate: { label: "Heart Rate", unit: "bpm", color: "#f72585", chartType: "line", sublabel: "latest" },
+  sleep: { label: "Sleep", unit: "hrs", color: "#7b2cbf", chartType: "bar", sublabel: "last night" },
+  activeEnergy: { label: "Active Energy", unit: "kcal", color: "#ff9e00", chartType: "bar", sublabel: "today" },
+  walkingDistance: { label: "Walking Distance", unit: "km", color: "#06d6a0", chartType: "bar", sublabel: "today" },
+  weight: { label: "Weight", unit: "kg", color: "#4895ef", chartType: "line", sublabel: "latest" },
+  meditation: { label: "Meditation", unit: "min", color: "#e0aaff", chartType: "bar", sublabel: "today" },
 };
 
 /** A single-value day bucket (used by most metrics). */


### PR DESCRIPTION
## Summary

- Tap any metric card to see a full-screen 7-day detail sheet with chart and daily breakdown
- New `lib/weekly.ts` with pure data aggregation functions (36 tests)
- New `components/` directory with BarChart, LineChart, and MetricDetailSheet
- Per-metric HealthKit queries with lazy fetching and caching
- Slide-up animation with swipe-to-dismiss

## Test plan

- [ ] Run `npm test` — all 110 tests pass
- [ ] Build on device with `npx expo run:ios --device`
- [ ] Tap "Grab Context", then tap each metric card
- [ ] Verify chart renders with 7-day data
- [ ] Verify daily breakdown shows correct values
- [ ] Swipe down to dismiss, tap ✕ to dismiss
- [ ] Tap overlay background to dismiss
- [ ] Re-tap same card (should use cache, no reload)
- [ ] Tap "Grab Context" again, re-tap card (cache should be cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tap any metric card to view a detailed 7-day breakdown with interactive visualizations
  * View weekly averages and per-day metrics in an animated bottom sheet
  * Dynamic charts (bar or line) display weekly trends; swipe down to dismiss
  * Daily breakdown list shows historical data with current averages

* **Documentation**
  * Added design specifications and implementation plans for the metric detail view

* **Tests**
  * Added comprehensive test coverage for weekly data aggregation and formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->