### PR TITLE
Add OTA update info to About page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import {
 import * as Location from "expo-location";
 import * as TaskManager from "expo-task-manager";
 import * as SQLite from "expo-sqlite";
+import * as Updates from "expo-updates";
 import HealthKit from "@kingstinct/react-native-healthkit";
 import type {
   QuantityTypeIdentifier,
@@ -232,6 +233,9 @@ function AboutModal({
   onClose: () => void;
 }) {
   const buildInfo = getBuildInfo();
+  const updateChannel = Updates.channel ?? "N/A";
+  const runtimeVersion = Updates.runtimeVersion ?? "N/A";
+  const updateId = Updates.updateId ?? "embedded";
 
   return (
     <Modal
@@ -286,6 +290,21 @@ function AboutModal({
                 </Text>
               </TouchableOpacity>
             ) : null}
+
+            <View style={styles.aboutRow}>
+              <Text style={styles.aboutRowLabel}>Channel</Text>
+              <Text style={styles.aboutRowValue}>{updateChannel}</Text>
+            </View>
+
+            <View style={styles.aboutRow}>
+              <Text style={styles.aboutRowLabel}>Runtime</Text>
+              <Text style={styles.aboutRowValue}>{runtimeVersion}</Text>
+            </View>
+
+            <View style={styles.aboutRow}>
+              <Text style={styles.aboutRowLabel}>Update</Text>
+              <Text style={styles.aboutRowValue}>{updateId}</Text>
+            </View>
 
             {buildInfo.repoUrl ? (
               <TouchableOpacity

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -40,6 +40,13 @@ jest.mock('@kingstinct/react-native-healthkit', () => ({
   },
 }));
 
+// Mock expo-updates
+jest.mock('expo-updates', () => ({
+  channel: 'development',
+  runtimeVersion: '1.0.0',
+  updateId: null,
+}));
+
 // Mock expo-status-bar
 jest.mock('expo-status-bar', () => ({
   StatusBar: 'StatusBar',


### PR DESCRIPTION
## Summary
- Show EAS update channel, runtime version, and update ID in the About modal
- Helps debug whether the device picked up the latest OTA push or is still on the embedded build
- Added expo-updates mock to jest.setup.js for test compatibility

## Test plan
- [ ] Open About page and verify Channel, Runtime, and Update rows appear
- [ ] Push an OTA update and confirm Update ID changes after app reload
- [ ] `npm test` passes (114 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new informational fields to the About section: Channel, Runtime Version, and Update ID. These fields now display the app's current deployment channel, runtime environment version, and update status. This enhancement provides users with better visibility into their app's version and deployment configuration, with graceful fallbacks for unavailable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->