### PR TITLE
Add box plots, known places, and sleep source breakdown

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1384,6 +1384,7 @@ export default function App() {
             setSelectedMetric(null);
             setWeeklyError(null);
           }}
+          sleepBySource={selectedMetric === "sleep" ? snapshot?.health.sleepBySource : undefined}
         />
       )}
     </View>

--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,6 @@ import {
   AppState,
   Modal,
   Linking,
-  Pressable,
 } from "react-native";
 import * as Location from "expo-location";
 import * as TaskManager from "expo-task-manager";
@@ -24,7 +23,7 @@ import type {
   QuantityTypeIdentifier,
   CategoryTypeIdentifier,
 } from "@kingstinct/react-native-healthkit";
-import { buildHealthData, type HealthData, type HealthQueryResults } from "./lib/health";
+import { buildHealthData, type HealthData, type HealthQueryResults, type SleepSample } from "./lib/health";
 import { pruneThreshold } from "./lib/location";
 import { buildSummary, formatNumber } from "./lib/summary";
 import { getBuildInfo, formatBuildTimestamp } from "./lib/version";
@@ -592,8 +591,8 @@ export default function App() {
       setError("Place name is required");
       return;
     }
-    if (isNaN(lat) || isNaN(lng)) {
-      setError("Valid latitude and longitude are required");
+    if (isNaN(lat) || isNaN(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      setError("Valid latitude (-90 to 90) and longitude (-180 to 180) required");
       return;
     }
     try {
@@ -645,7 +644,7 @@ export default function App() {
         const lat = Number(p.lat ?? p.latitude);
         const lng = Number(p.lon ?? p.lng ?? p.longitude);
         const radius = Number(p.radiusMeters ?? p.radius_meters ?? p.radius ?? 100);
-        if (!name || isNaN(lat) || isNaN(lng)) continue;
+        if (!name || isNaN(lat) || isNaN(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) continue;
         await addKnownPlace(db, name, lat, lng, radius);
         added++;
       }
@@ -714,17 +713,31 @@ export default function App() {
       ),
     ]);
 
-    // Map source names onto sleep samples for per-source summary
+    // Map source names onto sleep samples for per-source summary (new array, no mutation)
     const sleepResult = results[4];
+    let mappedSleep: PromiseSettledResult<SleepSample[]>;
     if (sleepResult.status === "fulfilled" && sleepResult.value) {
-      const mapped = (sleepResult.value as any[]).map((s: any) => ({
-        ...s,
-        source: s.sourceRevision?.source?.name ?? "Unknown",
-      }));
-      (results[4] as any) = { status: "fulfilled", value: mapped };
+      mappedSleep = {
+        status: "fulfilled" as const,
+        value: (sleepResult.value as any[]).map((s: any) => ({
+          startDate: s.startDate,
+          endDate: s.endDate,
+          value: s.value,
+          source: s.sourceRevision?.source?.name ?? "Unknown",
+        })),
+      };
+    } else {
+      mappedSleep = sleepResult.status === "fulfilled"
+        ? { status: "fulfilled" as const, value: [] }
+        : { status: "rejected" as const, reason: (sleepResult as PromiseRejectedResult).reason };
     }
+    const healthResults: HealthQueryResults = [
+      results[0], results[1], results[2], results[3],
+      mappedSleep,
+      results[5], results[6], results[7], results[8], results[9], results[10],
+    ] as HealthQueryResults;
 
-    return buildHealthData(results as HealthQueryResults);
+    return buildHealthData(healthResults);
   }
 
   async function grabLocation(): Promise<LocationData> {

--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,7 @@ import {
 } from "./lib/weekly";
 import { buildSummaryExport, type WeeklyDataMap, type LocationSummary } from "./lib/share";
 import { clusterLocations } from "./lib/clustering";
+import { type KnownPlace } from "./lib/places";
 import MetricDetailSheet from "./components/MetricDetailSheet";
 
 // --- Constants ---
@@ -106,6 +107,13 @@ async function initDB(db: SQLite.SQLiteDatabase): Promise<void> {
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS known_places (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      latitude REAL NOT NULL,
+      longitude REAL NOT NULL,
+      radius_meters REAL NOT NULL DEFAULT 100
+    );
     INSERT OR IGNORE INTO settings (key, value) VALUES ('schema_version', '1');
     INSERT OR IGNORE INTO settings (key, value) VALUES ('tracking_enabled', 'false');
     INSERT OR IGNORE INTO settings (key, value) VALUES ('retention_days', '30');
@@ -168,6 +176,45 @@ async function getLocationStorageBytes(db: SQLite.SQLiteDatabase): Promise<numbe
     "SELECT SUM(LENGTH(latitude) + LENGTH(longitude) + LENGTH(accuracy) + LENGTH(timestamp) + 20) as size FROM locations",
   );
   return row?.size ?? 0;
+}
+
+async function getKnownPlaces(
+  db: SQLite.SQLiteDatabase,
+): Promise<KnownPlace[]> {
+  const rows = await db.getAllAsync<{
+    id: number;
+    name: string;
+    latitude: number;
+    longitude: number;
+    radius_meters: number;
+  }>("SELECT id, name, latitude, longitude, radius_meters FROM known_places ORDER BY name ASC");
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    radiusMeters: r.radius_meters,
+  }));
+}
+
+async function addKnownPlace(
+  db: SQLite.SQLiteDatabase,
+  name: string,
+  latitude: number,
+  longitude: number,
+  radiusMeters: number,
+): Promise<void> {
+  await db.runAsync(
+    "INSERT INTO known_places (name, latitude, longitude, radius_meters) VALUES (?, ?, ?, ?)",
+    [name, latitude, longitude, radiusMeters],
+  );
+}
+
+async function deleteKnownPlace(
+  db: SQLite.SQLiteDatabase,
+  id: number,
+): Promise<void> {
+  await db.runAsync("DELETE FROM known_places WHERE id = ?", [id]);
 }
 
 async function getLocationHistory(
@@ -356,6 +403,11 @@ export default function App() {
   const [sharing, setSharing] = useState(false);
   const [shareStatus, setShareStatus] = useState("");
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [knownPlaces, setKnownPlaces] = useState<KnownPlace[]>([]);
+  const [newPlaceName, setNewPlaceName] = useState("");
+  const [newPlaceLat, setNewPlaceLat] = useState("");
+  const [newPlaceLng, setNewPlaceLng] = useState("");
+  const [newPlaceRadius, setNewPlaceRadius] = useState("100");
 
   // Initialize database on mount
   useEffect(() => {
@@ -373,6 +425,9 @@ export default function App() {
 
         const count = await getLocationCount(database);
         setLocationCount(count);
+
+        const places = await getKnownPlaces(database);
+        setKnownPlaces(places);
 
         // Prune on startup
         await pruneLocations(database, parseInt(days, 10) || 30);
@@ -511,6 +566,54 @@ export default function App() {
         }
       }
     }, 1000);
+  }
+
+  async function handleAddPlace() {
+    if (!db) {
+      setError("Database not available. Please restart the app.");
+      return;
+    }
+    const name = newPlaceName.trim();
+    const lat = parseFloat(newPlaceLat);
+    const lng = parseFloat(newPlaceLng);
+    const radius = parseFloat(newPlaceRadius) || 100;
+    if (!name) {
+      setError("Place name is required");
+      return;
+    }
+    if (isNaN(lat) || isNaN(lng)) {
+      setError("Valid latitude and longitude are required");
+      return;
+    }
+    try {
+      await addKnownPlace(db, name, lat, lng, radius);
+      const places = await getKnownPlaces(db);
+      setKnownPlaces(places);
+      setNewPlaceName("");
+      setNewPlaceLat("");
+      setNewPlaceLng("");
+      setNewPlaceRadius("100");
+    } catch (e: any) {
+      setError(e.message ?? "Failed to add place");
+    }
+  }
+
+  async function handleDeletePlace(id: number) {
+    if (!db) return;
+    try {
+      await deleteKnownPlace(db, id);
+      const places = await getKnownPlaces(db);
+      setKnownPlaces(places);
+    } catch (e: any) {
+      setError(e.message ?? "Failed to delete place");
+    }
+  }
+
+  function handleUseCurrentLocation() {
+    if (snapshot?.location) {
+      setNewPlaceLat(snapshot.location.latitude.toFixed(6));
+      setNewPlaceLng(snapshot.location.longitude.toFixed(6));
+    }
   }
 
   async function grabHealthData(): Promise<HealthData> {
@@ -784,7 +887,7 @@ export default function App() {
         setShareStatus(`Clustering ${snapshot.locationHistory.length} locations...`);
         // Yield to UI before heavy computation
         await new Promise((r) => setTimeout(r, 0));
-        const { clusters, timeline, summary } = clusterLocations(snapshot.locationHistory);
+        const { clusters, timeline, summary } = clusterLocations(snapshot.locationHistory, 50, 3, knownPlaces);
         locationSummary = { clusters, timeline, summary };
       }
       setShareStatus("Sharing...");
@@ -807,7 +910,7 @@ export default function App() {
     // Cluster location history instead of sharing raw points
     let locationClusters: LocationSummary | null = null;
     if (snapshot.locationHistory.length > 0) {
-      const { clusters, timeline, summary } = clusterLocations(snapshot.locationHistory);
+      const { clusters, timeline, summary } = clusterLocations(snapshot.locationHistory, 50, 3, knownPlaces);
       locationClusters = { clusters, timeline, summary };
     }
     const rawExport = {
@@ -999,6 +1102,81 @@ export default function App() {
                         : `${locationStorageBytes} B`})`
                   : ""}
               </Text>
+            </View>
+
+            <View style={styles.aboutCard}>
+              <Text style={styles.metricLabel}>Known Places</Text>
+              <Text style={styles.locationCountText}>
+                GPS points within radius will use these names instead of generic "Place N" labels
+              </Text>
+
+              {knownPlaces.map((place) => (
+                <View key={place.id} style={styles.knownPlaceRow}>
+                  <View style={styles.knownPlaceInfo}>
+                    <Text style={styles.knownPlaceName}>{place.name}</Text>
+                    <Text style={styles.knownPlaceDetail}>
+                      {place.latitude.toFixed(4)}, {place.longitude.toFixed(4)} ({place.radiusMeters}m)
+                    </Text>
+                  </View>
+                  <TouchableOpacity
+                    onPress={() => handleDeletePlace(place.id)}
+                    style={styles.knownPlaceDelete}
+                  >
+                    <Text style={styles.knownPlaceDeleteText}>X</Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+
+              <View style={styles.addPlaceForm}>
+                <TextInput
+                  style={styles.addPlaceInput}
+                  placeholder="Name"
+                  placeholderTextColor="#666"
+                  value={newPlaceName}
+                  onChangeText={setNewPlaceName}
+                />
+                <View style={styles.addPlaceCoordRow}>
+                  <TextInput
+                    style={[styles.addPlaceInput, styles.addPlaceCoordInput]}
+                    placeholder="Latitude"
+                    placeholderTextColor="#666"
+                    value={newPlaceLat}
+                    onChangeText={setNewPlaceLat}
+                    keyboardType="decimal-pad"
+                  />
+                  <TextInput
+                    style={[styles.addPlaceInput, styles.addPlaceCoordInput]}
+                    placeholder="Longitude"
+                    placeholderTextColor="#666"
+                    value={newPlaceLng}
+                    onChangeText={setNewPlaceLng}
+                    keyboardType="decimal-pad"
+                  />
+                </View>
+                <View style={styles.addPlaceCoordRow}>
+                  <TextInput
+                    style={[styles.addPlaceInput, styles.addPlaceCoordInput]}
+                    placeholder="Radius (m)"
+                    placeholderTextColor="#666"
+                    value={newPlaceRadius}
+                    onChangeText={setNewPlaceRadius}
+                    keyboardType="number-pad"
+                  />
+                  <TouchableOpacity
+                    style={[styles.addPlaceButton, { backgroundColor: "#3d405b" }]}
+                    onPress={handleUseCurrentLocation}
+                    disabled={!snapshot?.location}
+                  >
+                    <Text style={styles.addPlaceButtonText}>Use Current</Text>
+                  </TouchableOpacity>
+                </View>
+                <TouchableOpacity
+                  style={styles.addPlaceButton}
+                  onPress={handleAddPlace}
+                >
+                  <Text style={styles.addPlaceButtonText}>Add Place</Text>
+                </TouchableOpacity>
+              </View>
             </View>
           </ScrollView>
         </View>
@@ -1351,5 +1529,73 @@ const styles = StyleSheet.create({
   },
   aboutLink: {
     color: "#4361ee",
+  },
+  knownPlaceRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: "#1a1a2e",
+    marginTop: 4,
+  },
+  knownPlaceInfo: {
+    flex: 1,
+  },
+  knownPlaceName: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#e0e0e0",
+  },
+  knownPlaceDetail: {
+    fontSize: 12,
+    color: "#888",
+    marginTop: 2,
+  },
+  knownPlaceDelete: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "#3d1f1f",
+    justifyContent: "center",
+    alignItems: "center",
+    marginLeft: 8,
+  },
+  knownPlaceDeleteText: {
+    color: "#ff6b6b",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  addPlaceForm: {
+    marginTop: 12,
+    gap: 8,
+  },
+  addPlaceInput: {
+    backgroundColor: "#1a1a2e",
+    color: "#fff",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    borderWidth: 1,
+    borderColor: "#333",
+  },
+  addPlaceCoordRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  addPlaceCoordInput: {
+    flex: 1,
+  },
+  addPlaceButton: {
+    backgroundColor: "#2d6a4f",
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  addPlaceButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
   },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -682,6 +682,16 @@ export default function App() {
       ),
     ]);
 
+    // Map source names onto sleep samples for per-source summary
+    const sleepResult = results[4];
+    if (sleepResult.status === "fulfilled" && sleepResult.value) {
+      const mapped = (sleepResult.value as any[]).map((s: any) => ({
+        ...s,
+        source: s.sourceRevision?.source?.name ?? "Unknown",
+      }));
+      (results[4] as any) = { status: "fulfilled", value: mapped };
+    }
+
     return buildHealthData(results as HealthQueryResults);
   }
 

--- a/App.tsx
+++ b/App.tsx
@@ -418,6 +418,7 @@ export default function App() {
   const [newPlaceLat, setNewPlaceLat] = useState("");
   const [newPlaceLng, setNewPlaceLng] = useState("");
   const [newPlaceRadius, setNewPlaceRadius] = useState("100");
+  const [importJson, setImportJson] = useState("");
 
   // Initialize database on mount
   useEffect(() => {
@@ -623,6 +624,37 @@ export default function App() {
     if (snapshot?.location) {
       setNewPlaceLat(snapshot.location.latitude.toFixed(6));
       setNewPlaceLng(snapshot.location.longitude.toFixed(6));
+    }
+  }
+
+  async function handleImportPlacesJson(json: string) {
+    if (!db) {
+      setError("Database not available. Please restart the app.");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(json);
+      const items = Array.isArray(parsed) ? parsed : parsed.knownPlaces ?? parsed.places;
+      if (!Array.isArray(items)) {
+        setError("JSON must be an array or have a knownPlaces/places array");
+        return;
+      }
+      let added = 0;
+      for (const p of items) {
+        const name = String(p.name ?? "").trim();
+        const lat = Number(p.lat ?? p.latitude);
+        const lng = Number(p.lon ?? p.lng ?? p.longitude);
+        const radius = Number(p.radiusMeters ?? p.radius_meters ?? p.radius ?? 100);
+        if (!name || isNaN(lat) || isNaN(lng)) continue;
+        await addKnownPlace(db, name, lat, lng, radius);
+        added++;
+      }
+      const places = await getKnownPlaces(db);
+      setKnownPlaces(places);
+      setImportJson("");
+      if (added === 0) setError("No valid places found in JSON");
+    } catch (e: any) {
+      setError(e.message ?? "Invalid JSON");
     }
   }
 
@@ -1236,6 +1268,22 @@ export default function App() {
                   <Text style={styles.addPlaceButtonText}>Add Place</Text>
                 </TouchableOpacity>
               </View>
+
+              <Text style={[styles.knownPlaceName, { marginTop: 16 }]}>Import JSON</Text>
+              <TextInput
+                style={[styles.addPlaceInput, { height: 80, textAlignVertical: "top" }]}
+                placeholder='[{"name":"Home","lat":47.64,"lon":-122.30,"radiusMeters":100}]'
+                placeholderTextColor="#555"
+                value={importJson}
+                onChangeText={setImportJson}
+                multiline
+              />
+              <TouchableOpacity
+                style={styles.addPlaceButton}
+                onPress={() => handleImportPlacesJson(importJson)}
+              >
+                <Text style={styles.addPlaceButtonText}>Import Places</Text>
+              </TouchableOpacity>
             </View>
           </ScrollView>
         </View>

--- a/App.tsx
+++ b/App.tsx
@@ -32,6 +32,7 @@ import {
   type MetricKey,
   type DailyValue,
   type HeartRateDaily,
+  METRIC_CONFIG,
   aggregateHeartRate,
   aggregateSleep,
   aggregateMeditation,
@@ -39,7 +40,9 @@ import {
 } from "./lib/weekly";
 import { buildSummaryExport, type WeeklyDataMap, type LocationSummary } from "./lib/share";
 import { clusterLocations } from "./lib/clustering";
+import { computeBoxPlotStats, extractValues, type BoxPlotStats } from "./lib/stats";
 import MetricDetailSheet from "./components/MetricDetailSheet";
+import BoxPlot from "./components/BoxPlot";
 
 // --- Constants ---
 
@@ -216,9 +219,11 @@ type MetricCardProps = {
   sublabel: string;
   fullWidth?: boolean;
   onPress: (key: MetricKey) => void;
+  boxPlotStats?: BoxPlotStats | null;
+  color?: string;
 };
 
-function MetricCard({ metricKey, label, value, sublabel, fullWidth, onPress }: MetricCardProps) {
+function MetricCard({ metricKey, label, value, sublabel, fullWidth, onPress, boxPlotStats, color }: MetricCardProps) {
   const isNull = value === "\u2014";
   return (
     <TouchableOpacity
@@ -230,7 +235,11 @@ function MetricCard({ metricKey, label, value, sublabel, fullWidth, onPress }: M
       <Text style={[styles.metricValue, isNull && styles.metricValueNull]}>
         {value}
       </Text>
-      <Text style={styles.metricSublabel}>{sublabel}</Text>
+      {boxPlotStats && color ? (
+        <BoxPlot stats={boxPlotStats} color={color} />
+      ) : (
+        <Text style={styles.metricSublabel}>{sublabel}</Text>
+      )}
     </TouchableOpacity>
   );
 }
@@ -351,6 +360,7 @@ export default function App() {
   const [weeklyCache, setWeeklyCache] = useState<Partial<Record<MetricKey, DailyValue[] | HeartRateDaily[]>>>({});
   const [weeklyLoading, setWeeklyLoading] = useState(false);
   const [weeklyError, setWeeklyError] = useState<string | null>(null);
+  const [statsCache, setStatsCache] = useState<Partial<Record<MetricKey, BoxPlotStats | null>>>({});
   const [locationStorageBytes, setLocationStorageBytes] = useState(0);
   const [dbReady, setDbReady] = useState(false);
   const [sharing, setSharing] = useState(false);
@@ -687,6 +697,17 @@ export default function App() {
     }
   }
 
+  function computeStatsForMetric(key: MetricKey, data: DailyValue[] | HeartRateDaily[]): BoxPlotStats | null {
+    if ("avg" in (data[0] ?? {})) {
+      // HeartRateDaily: use avg values
+      const vals = (data as HeartRateDaily[])
+        .filter((d) => d.avg !== null)
+        .map((d) => d.avg as number);
+      return computeBoxPlotStats(vals);
+    }
+    return computeBoxPlotStats(extractValues(data as DailyValue[]));
+  }
+
   async function handleMetricPress(key: MetricKey) {
     setSelectedMetric(key);
     setWeeklyError(null);
@@ -695,6 +716,7 @@ export default function App() {
     try {
       const data = await grabWeeklyData(key);
       setWeeklyCache((prev) => ({ ...prev, [key]: data }));
+      setStatsCache((prev) => ({ ...prev, [key]: computeStatsForMetric(key, data) }));
     } catch (e: any) {
       setWeeklyError(e.message ?? "Failed to load weekly data");
     } finally {
@@ -706,6 +728,7 @@ export default function App() {
     setLoading(true);
     setError(null);
     setWeeklyCache({});
+    setStatsCache({});
     setWeeklyError(null);
     try {
       await HealthKit.requestAuthorization({
@@ -779,6 +802,12 @@ export default function App() {
         restingHeartRate: allMetrics[8] as DailyValue[],
         exerciseMinutes: allMetrics[9] as DailyValue[],
       };
+      // Compute and cache stats for all metrics during share
+      const newStats: Partial<Record<MetricKey, BoxPlotStats | null>> = {};
+      metricKeys.forEach((key, i) => {
+        newStats[key] = computeStatsForMetric(key, allMetrics[i]);
+      });
+      setStatsCache((prev) => ({ ...prev, ...newStats }));
       let locationSummary: LocationSummary | null = null;
       if (snapshot.locationHistory.length > 0) {
         setShareStatus(`Clustering ${snapshot.locationHistory.length} locations...`);
@@ -837,6 +866,8 @@ export default function App() {
           value: h?.steps != null ? formatNumber(h.steps) : "\u2014",
           sublabel: "today",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.steps,
+          color: METRIC_CONFIG.steps.color,
         },
         {
           metricKey: "heartRate" as MetricKey,
@@ -844,6 +875,8 @@ export default function App() {
           value: h?.heartRate != null ? `${h.heartRate} bpm` : "\u2014",
           sublabel: "latest",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.heartRate,
+          color: METRIC_CONFIG.heartRate.color,
         },
         {
           metricKey: "sleep" as MetricKey,
@@ -854,6 +887,8 @@ export default function App() {
               ? `${h.bedtime} \u2013 ${h.wakeTime}`
               : "last night",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.sleep,
+          color: METRIC_CONFIG.sleep.color,
         },
         {
           metricKey: "activeEnergy" as MetricKey,
@@ -861,6 +896,8 @@ export default function App() {
           value: h?.activeEnergy != null ? `${formatNumber(h.activeEnergy)} kcal` : "\u2014",
           sublabel: "today",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.activeEnergy,
+          color: METRIC_CONFIG.activeEnergy.color,
         },
         {
           metricKey: "walkingDistance" as MetricKey,
@@ -868,6 +905,8 @@ export default function App() {
           value: h?.walkingDistance != null ? `${h.walkingDistance} km` : "\u2014",
           sublabel: "today",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.walkingDistance,
+          color: METRIC_CONFIG.walkingDistance.color,
         },
         {
           metricKey: "weight" as MetricKey,
@@ -878,6 +917,8 @@ export default function App() {
               ? `${h.weightDaysLast7}/7 days weighed`
               : "latest",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.weight,
+          color: METRIC_CONFIG.weight.color,
         },
         {
           metricKey: "meditation" as MetricKey,
@@ -885,6 +926,8 @@ export default function App() {
           value: h?.meditationMinutes != null ? `${h.meditationMinutes} min` : "\u2014",
           sublabel: "today",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.meditation,
+          color: METRIC_CONFIG.meditation.color,
         },
         {
           metricKey: "hrv" as MetricKey,
@@ -892,6 +935,8 @@ export default function App() {
           value: h?.hrv != null ? `${h.hrv} ms` : "\u2014",
           sublabel: "latest",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.hrv,
+          color: METRIC_CONFIG.hrv.color,
         },
         {
           metricKey: "restingHeartRate" as MetricKey,
@@ -899,6 +944,8 @@ export default function App() {
           value: h?.restingHeartRate != null ? `${h.restingHeartRate} bpm` : "\u2014",
           sublabel: "latest",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.restingHeartRate,
+          color: METRIC_CONFIG.restingHeartRate.color,
         },
         {
           metricKey: "exerciseMinutes" as MetricKey,
@@ -906,6 +953,8 @@ export default function App() {
           value: h?.exerciseMinutes != null ? `${h.exerciseMinutes} min` : "\u2014",
           sublabel: "today",
           onPress: handleMetricPress,
+          boxPlotStats: statsCache.exerciseMinutes,
+          color: METRIC_CONFIG.exerciseMinutes.color,
         },
       ]
     : [];
@@ -1032,6 +1081,8 @@ export default function App() {
                   sublabel={m.sublabel}
                   fullWidth={metrics.length % 2 === 1 && i === metrics.length - 1}
                   onPress={handleMetricPress}
+                  boxPlotStats={m.boxPlotStats}
+                  color={m.color}
                 />
               ))}
             </View>

--- a/__tests__/health.test.ts
+++ b/__tests__/health.test.ts
@@ -2,13 +2,13 @@ import {
   calculateSleepHours,
   filterActualSleep,
   sleepCategoryName,
-  formatSleepSamples,
+  buildSleepBySource,
   calculateMeditationMinutes,
   extractWeight,
   countWeightDays,
   buildHealthData,
   type SleepSample,
-  type RawSleepSample,
+  type SourceSleepSummary,
   type MindfulSession,
   type WeightSample,
   type HealthQueryResults,
@@ -209,72 +209,76 @@ describe("sleepCategoryName", () => {
   });
 });
 
-describe("formatSleepSamples", () => {
+describe("buildSleepBySource", () => {
   it("returns null for undefined input", () => {
-    expect(formatSleepSamples(undefined)).toBeNull();
+    expect(buildSleepBySource(undefined)).toBeNull();
   });
 
   it("returns null for empty array", () => {
-    expect(formatSleepSamples([])).toBeNull();
+    expect(buildSleepBySource([])).toBeNull();
   });
 
-  it("formats samples with category names and ISO timestamps", () => {
+  it("groups samples by source with stage breakdown", () => {
     const samples: SleepSample[] = [
-      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", value: 0 },
-      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3 },
-      { startDate: "2026-03-15T01:00:00.000Z", endDate: "2026-03-15T03:00:00.000Z", value: 4 },
-      { startDate: "2026-03-15T03:15:00.000Z", endDate: "2026-03-15T05:00:00.000Z", value: 5 },
+      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3, source: "Apple Watch" },
+      { startDate: "2026-03-15T01:00:00.000Z", endDate: "2026-03-15T03:00:00.000Z", value: 4, source: "Apple Watch" },
+      { startDate: "2026-03-15T03:15:00.000Z", endDate: "2026-03-15T05:00:00.000Z", value: 5, source: "Apple Watch" },
+      { startDate: "2026-03-15T03:00:00.000Z", endDate: "2026-03-15T03:15:00.000Z", value: 2, source: "Apple Watch" },
     ];
-    const result = formatSleepSamples(samples);
-    expect(result).toEqual([
-      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", category: "InBed" },
-      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", category: "Core" },
-      { startDate: "2026-03-15T01:00:00.000Z", endDate: "2026-03-15T03:00:00.000Z", category: "Deep" },
-      { startDate: "2026-03-15T03:15:00.000Z", endDate: "2026-03-15T05:00:00.000Z", category: "REM" },
-    ]);
+    const result = buildSleepBySource(samples)!;
+    expect(result["Apple Watch"]).toBeDefined();
+    expect(result["Apple Watch"].bedtime).toBe("2026-03-14T22:30:00.000Z");
+    expect(result["Apple Watch"].wakeTime).toBe("2026-03-15T05:00:00.000Z");
+    expect(result["Apple Watch"].coreHours).toBe(2.5);
+    expect(result["Apple Watch"].deepHours).toBe(2);
+    expect(result["Apple Watch"].remHours).toBe(1.8);
+    expect(result["Apple Watch"].awakeHours).toBe(0.3);
   });
 
-  it("sorts samples by startDate ascending", () => {
+  it("separates multiple sources", () => {
     const samples: SleepSample[] = [
-      { startDate: "2026-03-15T03:00:00.000Z", endDate: "2026-03-15T05:00:00.000Z", value: 5 },
-      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3 },
+      { startDate: "2026-03-14T23:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", value: 3, source: "Apple Watch" },
+      { startDate: "2026-03-14T22:45:00.000Z", endDate: "2026-03-15T06:50:00.000Z", value: 4, source: "AutoSleep" },
     ];
-    const result = formatSleepSamples(samples)!;
-    expect(result[0].startDate).toBe("2026-03-14T22:00:00.000Z");
-    expect(result[1].startDate).toBe("2026-03-15T03:00:00.000Z");
+    const result = buildSleepBySource(samples)!;
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result["Apple Watch"]).toBeDefined();
+    expect(result["AutoSleep"]).toBeDefined();
+    expect(result["Apple Watch"].bedtime).toBe("2026-03-14T23:00:00.000Z");
+    expect(result["AutoSleep"].bedtime).toBe("2026-03-14T22:45:00.000Z");
   });
 
-  it("handles Date objects and converts to ISO strings", () => {
+  it("defaults to 'Unknown' source when not provided", () => {
+    const samples: SleepSample[] = [
+      { startDate: "2026-03-14T23:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", value: 3 },
+    ];
+    const result = buildSleepBySource(samples)!;
+    expect(result["Unknown"]).toBeDefined();
+    expect(result["Unknown"].coreHours).toBe(8);
+  });
+
+  it("handles Date objects", () => {
     const samples: SleepSample[] = [
       {
         startDate: new Date("2026-03-14T23:00:00.000Z"),
         endDate: new Date("2026-03-15T07:00:00.000Z"),
-        value: 1,
+        value: 4,
+        source: "Apple Watch",
       },
     ];
-    const result = formatSleepSamples(samples)!;
-    expect(result[0].startDate).toBe("2026-03-14T23:00:00.000Z");
-    expect(result[0].endDate).toBe("2026-03-15T07:00:00.000Z");
-    expect(result[0].category).toBe("Asleep");
+    const result = buildSleepBySource(samples)!;
+    expect(result["Apple Watch"].bedtime).toBe("2026-03-14T23:00:00.000Z");
+    expect(result["Apple Watch"].wakeTime).toBe("2026-03-15T07:00:00.000Z");
+    expect(result["Apple Watch"].deepHours).toBe(8);
   });
 
-  it("defaults to 'Asleep' when value is undefined (legacy data)", () => {
+  it("rounds hours to 1 decimal", () => {
+    // 7h 20m = 7.333... → 7.3
     const samples: SleepSample[] = [
-      { startDate: "2026-03-14T23:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z" },
+      { startDate: "2026-03-14T23:00:00.000Z", endDate: "2026-03-15T06:20:00.000Z", value: 5, source: "Watch" },
     ];
-    const result = formatSleepSamples(samples)!;
-    expect(result[0].category).toBe("Asleep");
-  });
-
-  it("includes ALL samples (InBed, Awake, etc.) in raw output", () => {
-    const samples: SleepSample[] = [
-      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", value: 0 },
-      { startDate: "2026-03-15T03:00:00.000Z", endDate: "2026-03-15T03:15:00.000Z", value: 2 },
-      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3 },
-    ];
-    const result = formatSleepSamples(samples)!;
-    expect(result).toHaveLength(3);
-    expect(result.map((s) => s.category)).toEqual(["InBed", "Core", "Awake"]);
+    const result = buildSleepBySource(samples)!;
+    expect(result["Watch"].remHours).toBe(7.3);
   });
 });
 
@@ -307,7 +311,7 @@ describe("buildHealthData", () => {
       sleepHours: null,
       bedtime: null,
       wakeTime: null,
-      sleepSamples: null,
+      sleepBySource: null,
       activeEnergy: null,
       walkingDistance: null,
       weight: null,
@@ -355,13 +359,14 @@ describe("buildHealthData", () => {
     expect(data.sleepHours).toBe(8);
     expect(data.bedtime).toBe("2026-03-14T23:00:00.000Z");
     expect(data.wakeTime).toBe("2026-03-15T07:00:00.000Z");
-    expect(data.sleepSamples).toEqual([
-      {
-        startDate: "2026-03-14T23:00:00.000Z",
-        endDate: "2026-03-15T07:00:00.000Z",
-        category: "Asleep",
+    // No source on test samples, so groups under "Unknown"
+    expect(data.sleepBySource).toEqual({
+      Unknown: {
+        bedtime: "2026-03-14T23:00:00.000Z",
+        wakeTime: "2026-03-15T07:00:00.000Z",
+        coreHours: 0, deepHours: 0, remHours: 0, awakeHours: 0,
       },
-    ]);
+    });
     expect(data.weight).toBe(75.5);
     expect(data.weightDaysLast7).toBe(3);
     expect(data.meditationMinutes).toBe(15);
@@ -387,7 +392,7 @@ describe("buildHealthData", () => {
     const data = buildHealthData(results);
     expect(data.heartRate).toBeNull();
     expect(data.sleepHours).toBeNull();
-    expect(data.sleepSamples).toBeNull();
+    expect(data.sleepBySource).toBeNull();
     expect(data.weight).toBeNull();
     expect(data.weightDaysLast7).toBeNull();
     expect(data.meditationMinutes).toBeNull();
@@ -440,13 +445,13 @@ describe("buildHealthData", () => {
     expect(data.activeEnergy).toBe(200);
     expect(data.walkingDistance).toBeNull();
     expect(data.sleepHours).toBe(3.5);
-    expect(data.sleepSamples).toEqual([
-      {
-        startDate: "2026-03-15T01:00:00.000Z",
-        endDate: "2026-03-15T04:30:00.000Z",
-        category: "Asleep",
+    expect(data.sleepBySource).toEqual({
+      Unknown: {
+        bedtime: "2026-03-15T01:00:00.000Z",
+        wakeTime: "2026-03-15T04:30:00.000Z",
+        coreHours: 0, deepHours: 0, remHours: 0, awakeHours: 0,
       },
-    ]);
+    });
     expect(data.weight).toBe(80.12);
     expect(data.weightDaysLast7).toBe(1);
     expect(data.meditationMinutes).toBeNull();

--- a/__tests__/health.test.ts
+++ b/__tests__/health.test.ts
@@ -1,11 +1,14 @@
 import {
   calculateSleepHours,
   filterActualSleep,
+  sleepCategoryName,
+  formatSleepSamples,
   calculateMeditationMinutes,
   extractWeight,
   countWeightDays,
   buildHealthData,
   type SleepSample,
+  type RawSleepSample,
   type MindfulSession,
   type WeightSample,
   type HealthQueryResults,
@@ -187,6 +190,94 @@ describe("filterActualSleep", () => {
   });
 });
 
+describe("sleepCategoryName", () => {
+  it("maps known sleep values to category names", () => {
+    expect(sleepCategoryName(0)).toBe("InBed");
+    expect(sleepCategoryName(1)).toBe("Asleep");
+    expect(sleepCategoryName(2)).toBe("Awake");
+    expect(sleepCategoryName(3)).toBe("Core");
+    expect(sleepCategoryName(4)).toBe("Deep");
+    expect(sleepCategoryName(5)).toBe("REM");
+  });
+
+  it("returns 'Asleep' for undefined (legacy data)", () => {
+    expect(sleepCategoryName(undefined)).toBe("Asleep");
+  });
+
+  it("returns 'Unknown' for unrecognized values", () => {
+    expect(sleepCategoryName(99)).toBe("Unknown");
+  });
+});
+
+describe("formatSleepSamples", () => {
+  it("returns null for undefined input", () => {
+    expect(formatSleepSamples(undefined)).toBeNull();
+  });
+
+  it("returns null for empty array", () => {
+    expect(formatSleepSamples([])).toBeNull();
+  });
+
+  it("formats samples with category names and ISO timestamps", () => {
+    const samples: SleepSample[] = [
+      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", value: 0 },
+      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3 },
+      { startDate: "2026-03-15T01:00:00.000Z", endDate: "2026-03-15T03:00:00.000Z", value: 4 },
+      { startDate: "2026-03-15T03:15:00.000Z", endDate: "2026-03-15T05:00:00.000Z", value: 5 },
+    ];
+    const result = formatSleepSamples(samples);
+    expect(result).toEqual([
+      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", category: "InBed" },
+      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", category: "Core" },
+      { startDate: "2026-03-15T01:00:00.000Z", endDate: "2026-03-15T03:00:00.000Z", category: "Deep" },
+      { startDate: "2026-03-15T03:15:00.000Z", endDate: "2026-03-15T05:00:00.000Z", category: "REM" },
+    ]);
+  });
+
+  it("sorts samples by startDate ascending", () => {
+    const samples: SleepSample[] = [
+      { startDate: "2026-03-15T03:00:00.000Z", endDate: "2026-03-15T05:00:00.000Z", value: 5 },
+      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3 },
+    ];
+    const result = formatSleepSamples(samples)!;
+    expect(result[0].startDate).toBe("2026-03-14T22:00:00.000Z");
+    expect(result[1].startDate).toBe("2026-03-15T03:00:00.000Z");
+  });
+
+  it("handles Date objects and converts to ISO strings", () => {
+    const samples: SleepSample[] = [
+      {
+        startDate: new Date("2026-03-14T23:00:00.000Z"),
+        endDate: new Date("2026-03-15T07:00:00.000Z"),
+        value: 1,
+      },
+    ];
+    const result = formatSleepSamples(samples)!;
+    expect(result[0].startDate).toBe("2026-03-14T23:00:00.000Z");
+    expect(result[0].endDate).toBe("2026-03-15T07:00:00.000Z");
+    expect(result[0].category).toBe("Asleep");
+  });
+
+  it("defaults to 'Asleep' when value is undefined (legacy data)", () => {
+    const samples: SleepSample[] = [
+      { startDate: "2026-03-14T23:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z" },
+    ];
+    const result = formatSleepSamples(samples)!;
+    expect(result[0].category).toBe("Asleep");
+  });
+
+  it("includes ALL samples (InBed, Awake, etc.) in raw output", () => {
+    const samples: SleepSample[] = [
+      { startDate: "2026-03-14T22:00:00.000Z", endDate: "2026-03-15T07:00:00.000Z", value: 0 },
+      { startDate: "2026-03-15T03:00:00.000Z", endDate: "2026-03-15T03:15:00.000Z", value: 2 },
+      { startDate: "2026-03-14T22:30:00.000Z", endDate: "2026-03-15T01:00:00.000Z", value: 3 },
+    ];
+    const result = formatSleepSamples(samples)!;
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.category)).toEqual(["InBed", "Core", "Awake"]);
+  });
+});
+
 describe("buildHealthData", () => {
   function fulfilled<T>(value: T): PromiseFulfilledResult<T> {
     return { status: "fulfilled", value };
@@ -216,6 +307,7 @@ describe("buildHealthData", () => {
       sleepHours: null,
       bedtime: null,
       wakeTime: null,
+      sleepSamples: null,
       activeEnergy: null,
       walkingDistance: null,
       weight: null,
@@ -263,6 +355,13 @@ describe("buildHealthData", () => {
     expect(data.sleepHours).toBe(8);
     expect(data.bedtime).toBe("2026-03-14T23:00:00.000Z");
     expect(data.wakeTime).toBe("2026-03-15T07:00:00.000Z");
+    expect(data.sleepSamples).toEqual([
+      {
+        startDate: "2026-03-14T23:00:00.000Z",
+        endDate: "2026-03-15T07:00:00.000Z",
+        category: "Asleep",
+      },
+    ]);
     expect(data.weight).toBe(75.5);
     expect(data.weightDaysLast7).toBe(3);
     expect(data.meditationMinutes).toBe(15);
@@ -288,6 +387,7 @@ describe("buildHealthData", () => {
     const data = buildHealthData(results);
     expect(data.heartRate).toBeNull();
     expect(data.sleepHours).toBeNull();
+    expect(data.sleepSamples).toBeNull();
     expect(data.weight).toBeNull();
     expect(data.weightDaysLast7).toBeNull();
     expect(data.meditationMinutes).toBeNull();
@@ -340,6 +440,13 @@ describe("buildHealthData", () => {
     expect(data.activeEnergy).toBe(200);
     expect(data.walkingDistance).toBeNull();
     expect(data.sleepHours).toBe(3.5);
+    expect(data.sleepSamples).toEqual([
+      {
+        startDate: "2026-03-15T01:00:00.000Z",
+        endDate: "2026-03-15T04:30:00.000Z",
+        category: "Asleep",
+      },
+    ]);
     expect(data.weight).toBe(80.12);
     expect(data.weightDaysLast7).toBe(1);
     expect(data.meditationMinutes).toBeNull();

--- a/__tests__/places.test.ts
+++ b/__tests__/places.test.ts
@@ -1,0 +1,313 @@
+import {
+  matchPointToPlace,
+  labelPointsWithKnownPlaces,
+  buildKnownPlaceClusters,
+  type KnownPlace,
+} from "../lib/places";
+import { haversineDistance, clusterLocations, type LocationPoint } from "../lib/clustering";
+
+// Helper to make a LocationPoint
+function pt(
+  lat: number,
+  lng: number,
+  timestamp: number,
+  accuracy: number | null = 10,
+): LocationPoint {
+  return { latitude: lat, longitude: lng, accuracy, timestamp };
+}
+
+// ─── matchPointToPlace ──────────────────────────────────────────────────────
+
+describe("matchPointToPlace", () => {
+  const places: KnownPlace[] = [
+    { id: 1, name: "Home", latitude: 47.6062, longitude: -122.3321, radiusMeters: 100 },
+    { id: 2, name: "Work", latitude: 47.6200, longitude: -122.3500, radiusMeters: 200 },
+  ];
+
+  it("returns -1 when no places match", () => {
+    const result = matchPointToPlace(0, 0, places);
+    expect(result.placeIndex).toBe(-1);
+    expect(result.distance).toBe(Infinity);
+  });
+
+  it("returns -1 for empty places array", () => {
+    const result = matchPointToPlace(47.6062, -122.3321, []);
+    expect(result.placeIndex).toBe(-1);
+  });
+
+  it("matches a point exactly at the place", () => {
+    const result = matchPointToPlace(47.6062, -122.3321, places);
+    expect(result.placeIndex).toBe(0);
+    expect(result.distance).toBe(0);
+  });
+
+  it("matches a point within radius", () => {
+    // ~10m from Home
+    const result = matchPointToPlace(47.6063, -122.3321, places);
+    expect(result.placeIndex).toBe(0);
+    expect(result.distance).toBeGreaterThan(0);
+    expect(result.distance).toBeLessThan(100);
+  });
+
+  it("does not match a point outside radius", () => {
+    // ~200m from Home, outside 100m radius
+    const result = matchPointToPlace(47.608, -122.3321, places);
+    expect(result.placeIndex).toBe(-1);
+  });
+
+  it("matches the closest place when multiple are within radius", () => {
+    // Create overlapping places
+    const overlapping: KnownPlace[] = [
+      { id: 1, name: "Place A", latitude: 47.6062, longitude: -122.3321, radiusMeters: 500 },
+      { id: 2, name: "Place B", latitude: 47.6065, longitude: -122.3321, radiusMeters: 500 },
+    ];
+    // Point is closer to Place B
+    const result = matchPointToPlace(47.6066, -122.3321, overlapping);
+    expect(result.placeIndex).toBe(1);
+  });
+});
+
+// ─── labelPointsWithKnownPlaces ─────────────────────────────────────────────
+
+describe("labelPointsWithKnownPlaces", () => {
+  const places: KnownPlace[] = [
+    { id: 1, name: "Home", latitude: 47.6062, longitude: -122.3321, radiusMeters: 100 },
+    { id: 2, name: "Work", latitude: 47.6200, longitude: -122.3500, radiusMeters: 200 },
+  ];
+
+  it("labels all points as -1 when no places defined", () => {
+    const points = [pt(47.6062, -122.3321, 1000), pt(47.6200, -122.3500, 2000)];
+    const labels = labelPointsWithKnownPlaces(points, []);
+    expect(labels).toEqual([-1, -1]);
+  });
+
+  it("labels points matching known places", () => {
+    const points = [
+      pt(47.6062, -122.3321, 1000), // at Home
+      pt(47.6200, -122.3500, 2000), // at Work
+      pt(0, 0, 3000),               // nowhere
+    ];
+    const labels = labelPointsWithKnownPlaces(points, places);
+    expect(labels[0]).toBe(0); // Home
+    expect(labels[1]).toBe(1); // Work
+    expect(labels[2]).toBe(-1); // unmatched
+  });
+
+  it("labels all points within Home radius as 0", () => {
+    const points = [
+      pt(47.6062, -122.3321, 1000),
+      pt(47.6063, -122.3322, 2000),
+      pt(47.6061, -122.3320, 3000),
+    ];
+    const labels = labelPointsWithKnownPlaces(points, places);
+    expect(labels).toEqual([0, 0, 0]);
+  });
+});
+
+// ─── buildKnownPlaceClusters ────────────────────────────────────────────────
+
+describe("buildKnownPlaceClusters", () => {
+  const places: KnownPlace[] = [
+    { id: 1, name: "Home", latitude: 47.6062, longitude: -122.3321, radiusMeters: 100 },
+    { id: 2, name: "Work", latitude: 47.6200, longitude: -122.3500, radiusMeters: 200 },
+  ];
+
+  it("returns empty array when no points match", () => {
+    const points = [pt(0, 0, 1000)];
+    const labels = [-1];
+    const clusters = buildKnownPlaceClusters(points, labels, places);
+    expect(clusters).toEqual([]);
+  });
+
+  it("builds cluster for matched points", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 8, 0, 0);
+    const points = [
+      pt(47.6062, -122.3321, ts),
+      pt(47.6063, -122.3322, ts + hourMs),
+      pt(47.6061, -122.3320, ts + 2 * hourMs),
+    ];
+    const labels = [0, 0, 0]; // all Home
+    const clusters = buildKnownPlaceClusters(points, labels, places);
+
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].id).toBe("Home");
+    expect(clusters[0].center.latitude).toBe(47.6062);
+    expect(clusters[0].center.longitude).toBe(-122.3321);
+    expect(clusters[0].pointCount).toBe(3);
+    expect(clusters[0].dwellTimeHours).toBe(2);
+  });
+
+  it("builds separate clusters for different known places", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 8, 0, 0);
+    const points = [
+      pt(47.6062, -122.3321, ts),
+      pt(47.6063, -122.3322, ts + hourMs),
+      pt(47.6200, -122.3500, ts + 3 * hourMs),
+      pt(47.6201, -122.3501, ts + 4 * hourMs),
+    ];
+    const labels = [0, 0, 1, 1];
+    const clusters = buildKnownPlaceClusters(points, labels, places);
+
+    expect(clusters).toHaveLength(2);
+    const homeCluster = clusters.find((c) => c.id === "Home");
+    const workCluster = clusters.find((c) => c.id === "Work");
+    expect(homeCluster).toBeDefined();
+    expect(workCluster).toBeDefined();
+    expect(homeCluster!.pointCount).toBe(2);
+    expect(workCluster!.pointCount).toBe(2);
+  });
+
+  it("caps dwell time gaps at 2 hours", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 0, 0, 0);
+    const points = [
+      pt(47.6062, -122.3321, ts),
+      pt(47.6063, -122.3322, ts + 5 * hourMs), // 5h gap, capped to 2h
+      pt(47.6061, -122.3320, ts + 6 * hourMs), // 1h gap
+    ];
+    const labels = [0, 0, 0];
+    const clusters = buildKnownPlaceClusters(points, labels, places);
+
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].dwellTimeHours).toBe(3); // 2h (capped) + 1h
+  });
+});
+
+// ─── clusterLocations with known places ─────────────────────────────────────
+
+describe("clusterLocations with known places", () => {
+  const places: KnownPlace[] = [
+    { id: 1, name: "Home", latitude: 47.6062, longitude: -122.3321, radiusMeters: 100 },
+    { id: 2, name: "Work", latitude: 47.6200, longitude: -122.3500, radiusMeters: 200 },
+  ];
+
+  it("uses known place names in clusters", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 8, 0, 0);
+    const points: LocationPoint[] = [];
+
+    // 5 points at Home
+    for (let i = 0; i < 5; i++) {
+      points.push(pt(
+        47.6062 + (Math.random() - 0.5) * 0.0002,
+        -122.3321 + (Math.random() - 0.5) * 0.0002,
+        ts + i * hourMs,
+      ));
+    }
+
+    const result = clusterLocations(points, 50, 3, places);
+    expect(result.clusters.length).toBeGreaterThanOrEqual(1);
+    const homeCluster = result.clusters.find((c) => c.id === "Home");
+    expect(homeCluster).toBeDefined();
+    expect(homeCluster!.pointCount).toBe(5);
+  });
+
+  it("falls back to generic clustering for unmatched points", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 0, 0, 0);
+    const points: LocationPoint[] = [];
+
+    // 3 points at Home (known place)
+    for (let i = 0; i < 3; i++) {
+      points.push(pt(47.6062, -122.3321, ts + i * hourMs));
+    }
+
+    // 5 points at unknown location (far from known places)
+    for (let i = 0; i < 5; i++) {
+      points.push(pt(
+        48.0000 + i * 0.0001,
+        -121.0000,
+        ts + (3 + i) * hourMs,
+      ));
+    }
+
+    const result = clusterLocations(points, 500, 3, places);
+
+    // Should have Home + a generic cluster
+    const homeCluster = result.clusters.find((c) => c.id === "Home");
+    expect(homeCluster).toBeDefined();
+    expect(homeCluster!.pointCount).toBe(3);
+
+    const genericClusters = result.clusters.filter((c) => c.id.startsWith("place_"));
+    expect(genericClusters.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses known place names in timeline", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 8, 0, 0);
+    const points: LocationPoint[] = [];
+
+    // 4 points at Home
+    for (let i = 0; i < 4; i++) {
+      points.push(pt(47.6062, -122.3321, ts + i * hourMs));
+    }
+    // 4 points at Work
+    for (let i = 0; i < 4; i++) {
+      points.push(pt(47.6200, -122.3500, ts + (5 + i) * hourMs));
+    }
+
+    const result = clusterLocations(points, 50, 3, places);
+
+    // Timeline should reference Home and Work
+    const homeVisit = result.timeline.find((v) => v.placeId === "Home");
+    const workVisit = result.timeline.find((v) => v.placeId === "Work");
+    expect(homeVisit).toBeDefined();
+    expect(workVisit).toBeDefined();
+  });
+
+  it("uses known place names in summary", () => {
+    const hourMs = 60 * 60 * 1000;
+    const ts = Date.UTC(2026, 2, 15, 8, 0, 0);
+    const points: LocationPoint[] = [];
+
+    for (let i = 0; i < 4; i++) {
+      points.push(pt(47.6062, -122.3321, ts + i * hourMs));
+    }
+    for (let i = 0; i < 4; i++) {
+      points.push(pt(47.6200, -122.3500, ts + (5 + i) * hourMs));
+    }
+
+    const result = clusterLocations(points, 50, 3, places);
+    expect(result.summary).toContain("Home");
+    expect(result.summary).toContain("Work");
+  });
+
+  it("works without known places (backward compatible)", () => {
+    const ts = Date.UTC(2026, 2, 15, 8, 0, 0);
+    const hourMs = 60 * 60 * 1000;
+    const points = Array.from({ length: 5 }, (_, i) =>
+      pt(47.6, -122.3, ts + i * hourMs),
+    );
+    const result = clusterLocations(points, 150, 3);
+    expect(result.clusters).toHaveLength(1);
+    expect(result.clusters[0].id).toBe("place_1");
+  });
+
+  it("returns empty result for empty input with known places", () => {
+    const result = clusterLocations([], 50, 3, places);
+    expect(result.clusters).toEqual([]);
+    expect(result.timeline).toEqual([]);
+    expect(result.summary).toBe("");
+  });
+});
+
+// ─── Distance calculation verification ──────────────────────────────────────
+
+describe("haversine distance for known places matching", () => {
+  it("correctly identifies points within 100m radius", () => {
+    // Home at (47.6062, -122.3321)
+    // A point ~50m away
+    const dist = haversineDistance(47.6062, -122.3321, 47.60665, -122.3321);
+    expect(dist).toBeLessThan(100);
+    expect(dist).toBeGreaterThan(30);
+  });
+
+  it("correctly identifies points outside 100m radius", () => {
+    // Home at (47.6062, -122.3321)
+    // A point ~200m away
+    const dist = haversineDistance(47.6062, -122.3321, 47.608, -122.3321);
+    expect(dist).toBeGreaterThan(100);
+  });
+});

--- a/__tests__/share.test.ts
+++ b/__tests__/share.test.ts
@@ -1,4 +1,4 @@
-import { dayOfWeek, buildDailyExport, type WeeklyDataMap } from "../lib/share";
+import { dayOfWeek, buildDailyExport, buildSummaryExport, buildWeeklyStats, type WeeklyDataMap } from "../lib/share";
 
 describe("dayOfWeek", () => {
   it("returns correct day names", () => {
@@ -115,5 +115,93 @@ describe("buildDailyExport", () => {
       expect(entry).not.toHaveProperty("location");
       expect(entry).not.toHaveProperty("locationHistory");
     }
+  });
+});
+
+describe("buildWeeklyStats", () => {
+  const dates = [
+    "2026-03-09", "2026-03-10", "2026-03-11", "2026-03-12",
+    "2026-03-13", "2026-03-14", "2026-03-15",
+  ];
+
+  const makeData = (overrides?: Partial<WeeklyDataMap>): WeeklyDataMap => ({
+    steps: dates.map((d) => ({ date: d, value: null })),
+    heartRate: dates.map((d) => ({ date: d, avg: null, min: null, max: null })),
+    sleep: dates.map((d) => ({ date: d, value: null })),
+    activeEnergy: dates.map((d) => ({ date: d, value: null })),
+    walkingDistance: dates.map((d) => ({ date: d, value: null })),
+    weight: dates.map((d) => ({ date: d, value: null })),
+    meditation: dates.map((d) => ({ date: d, value: null })),
+    hrv: dates.map((d) => ({ date: d, value: null })),
+    restingHeartRate: dates.map((d) => ({ date: d, value: null })),
+    exerciseMinutes: dates.map((d) => ({ date: d, value: null })),
+    ...overrides,
+  });
+
+  it("returns null stats when all values are null", () => {
+    const stats = buildWeeklyStats(makeData());
+    expect(stats.steps).toBeNull();
+    expect(stats.heartRate).toBeNull();
+    expect(stats.sleepHours).toBeNull();
+    expect(stats.activeEnergy).toBeNull();
+    expect(stats.walkingDistanceKm).toBeNull();
+    expect(stats.weightKg).toBeNull();
+    expect(stats.meditationMinutes).toBeNull();
+    expect(stats.hrvMs).toBeNull();
+    expect(stats.restingHeartRate).toBeNull();
+    expect(stats.exerciseMinutes).toBeNull();
+  });
+
+  it("computes stats for steps with data", () => {
+    const steps = dates.map((d, i) => ({
+      date: d,
+      value: [5000, 8000, 12000, 7500, 9000, 6000, 11000][i],
+    }));
+    const stats = buildWeeklyStats(makeData({ steps }));
+    expect(stats.steps).not.toBeNull();
+    expect(stats.steps!.min).toBe(5000);
+    expect(stats.steps!.max).toBe(12000);
+    expect(stats.steps!.p50).toBe(8000);
+    // Stats export should not have a values array
+    expect(stats.steps).not.toHaveProperty("values");
+  });
+
+  it("computes stats for heart rate using avg values", () => {
+    const heartRate = dates.map((d, i) => ({
+      date: d,
+      avg: [65, 70, 72, 68, 75, 71, 69][i],
+      min: 50,
+      max: 120,
+    }));
+    const stats = buildWeeklyStats(makeData({ heartRate }));
+    expect(stats.heartRate).not.toBeNull();
+    expect(stats.heartRate!.p50).toBe(70);
+  });
+});
+
+describe("buildSummaryExport", () => {
+  const dates = [
+    "2026-03-09", "2026-03-10", "2026-03-11", "2026-03-12",
+    "2026-03-13", "2026-03-14", "2026-03-15",
+  ];
+
+  const makeData = (): WeeklyDataMap => ({
+    steps: dates.map((d) => ({ date: d, value: null })),
+    heartRate: dates.map((d) => ({ date: d, avg: null, min: null, max: null })),
+    sleep: dates.map((d) => ({ date: d, value: null })),
+    activeEnergy: dates.map((d) => ({ date: d, value: null })),
+    walkingDistance: dates.map((d) => ({ date: d, value: null })),
+    weight: dates.map((d) => ({ date: d, value: null })),
+    meditation: dates.map((d) => ({ date: d, value: null })),
+    hrv: dates.map((d) => ({ date: d, value: null })),
+    restingHeartRate: dates.map((d) => ({ date: d, value: null })),
+    exerciseMinutes: dates.map((d) => ({ date: d, value: null })),
+  });
+
+  it("includes weeklyStats in export", () => {
+    const result = buildSummaryExport(makeData(), null);
+    expect(result).toHaveProperty("days");
+    expect(result).toHaveProperty("weeklyStats");
+    expect(result).toHaveProperty("locationSummary");
   });
 });

--- a/__tests__/snapshot.test.ts
+++ b/__tests__/snapshot.test.ts
@@ -77,8 +77,8 @@ describe("ContextSnapshot shape", () => {
       "hrv",
       "meditationMinutes",
       "restingHeartRate",
+      "sleepBySource",
       "sleepHours",
-      "sleepSamples",
       "steps",
       "wakeTime",
       "walkingDistance",
@@ -146,13 +146,13 @@ describe("ContextSnapshot shape", () => {
     expect(snapshot.health.sleepHours).toBe(8);
     expect(snapshot.health.bedtime).toBe("2026-03-14T23:00:00.000Z");
     expect(snapshot.health.wakeTime).toBe("2026-03-15T07:00:00.000Z");
-    expect(snapshot.health.sleepSamples).toEqual([
-      {
-        startDate: "2026-03-14T23:00:00.000Z",
-        endDate: "2026-03-15T07:00:00.000Z",
-        category: "Asleep",
+    expect(snapshot.health.sleepBySource).toEqual({
+      Unknown: {
+        bedtime: "2026-03-14T23:00:00.000Z",
+        wakeTime: "2026-03-15T07:00:00.000Z",
+        coreHours: 0, deepHours: 0, remHours: 0, awakeHours: 0,
       },
-    ]);
+    });
     expect(snapshot.health.weight).toBe(72.5);
     expect(snapshot.health.weightDaysLast7).toBe(2);
     expect(snapshot.health.meditationMinutes).toBe(20);
@@ -172,7 +172,7 @@ describe("ContextSnapshot shape", () => {
     expect(parsed.health.sleepHours).toBeNull();
     expect(parsed.health.bedtime).toBeNull();
     expect(parsed.health.wakeTime).toBeNull();
-    expect(parsed.health.sleepSamples).toBeNull();
+    expect(parsed.health.sleepBySource).toBeNull();
     expect(parsed.health.activeEnergy).toBeNull();
     expect(parsed.health.walkingDistance).toBeNull();
     expect(parsed.health.weight).toBeNull();

--- a/__tests__/snapshot.test.ts
+++ b/__tests__/snapshot.test.ts
@@ -78,6 +78,7 @@ describe("ContextSnapshot shape", () => {
       "meditationMinutes",
       "restingHeartRate",
       "sleepHours",
+      "sleepSamples",
       "steps",
       "wakeTime",
       "walkingDistance",
@@ -145,6 +146,13 @@ describe("ContextSnapshot shape", () => {
     expect(snapshot.health.sleepHours).toBe(8);
     expect(snapshot.health.bedtime).toBe("2026-03-14T23:00:00.000Z");
     expect(snapshot.health.wakeTime).toBe("2026-03-15T07:00:00.000Z");
+    expect(snapshot.health.sleepSamples).toEqual([
+      {
+        startDate: "2026-03-14T23:00:00.000Z",
+        endDate: "2026-03-15T07:00:00.000Z",
+        category: "Asleep",
+      },
+    ]);
     expect(snapshot.health.weight).toBe(72.5);
     expect(snapshot.health.weightDaysLast7).toBe(2);
     expect(snapshot.health.meditationMinutes).toBe(20);
@@ -164,6 +172,7 @@ describe("ContextSnapshot shape", () => {
     expect(parsed.health.sleepHours).toBeNull();
     expect(parsed.health.bedtime).toBeNull();
     expect(parsed.health.wakeTime).toBeNull();
+    expect(parsed.health.sleepSamples).toBeNull();
     expect(parsed.health.activeEnergy).toBeNull();
     expect(parsed.health.walkingDistance).toBeNull();
     expect(parsed.health.weight).toBeNull();

--- a/__tests__/stats.test.ts
+++ b/__tests__/stats.test.ts
@@ -1,0 +1,166 @@
+import {
+  percentile,
+  computeBoxPlotStats,
+  extractValues,
+  type BoxPlotStats,
+} from "../lib/stats";
+
+// ─── percentile ────────────────────────────────────────────────────────────────
+
+describe("percentile", () => {
+  it("returns the single value for a 1-element array", () => {
+    expect(percentile([42], 0.5)).toBe(42);
+    expect(percentile([42], 0)).toBe(42);
+    expect(percentile([42], 1)).toBe(42);
+  });
+
+  it("returns exact values at 0 and 1", () => {
+    const sorted = [10, 20, 30, 40, 50];
+    expect(percentile(sorted, 0)).toBe(10);
+    expect(percentile(sorted, 1)).toBe(50);
+  });
+
+  it("returns median for even-length array", () => {
+    // [1, 2, 3, 4] — median interpolates between 2 and 3
+    expect(percentile([1, 2, 3, 4], 0.5)).toBe(2.5);
+  });
+
+  it("returns median for odd-length array", () => {
+    expect(percentile([1, 2, 3, 4, 5], 0.5)).toBe(3);
+  });
+
+  it("interpolates correctly for p25", () => {
+    // [0, 10, 20, 30, 40] — p25: index = 0.25 * 4 = 1.0 → exact 10
+    expect(percentile([0, 10, 20, 30, 40], 0.25)).toBe(10);
+  });
+
+  it("interpolates between values", () => {
+    // [0, 100] — p50: index = 0.5 * 1 = 0.5 → 0 + 0.5 * (100 - 0) = 50
+    expect(percentile([0, 100], 0.5)).toBe(50);
+    // p25: index = 0.25 * 1 = 0.25 → 0 + 0.25 * 100 = 25
+    expect(percentile([0, 100], 0.25)).toBe(25);
+  });
+
+  it("throws on empty array", () => {
+    expect(() => percentile([], 0.5)).toThrow("Cannot compute percentile of empty array");
+  });
+});
+
+// ─── computeBoxPlotStats ──────────────────────────────────────────────────────
+
+describe("computeBoxPlotStats", () => {
+  it("returns null for empty array", () => {
+    expect(computeBoxPlotStats([])).toBeNull();
+  });
+
+  it("returns null for array of non-finite values", () => {
+    expect(computeBoxPlotStats([NaN, Infinity, -Infinity])).toBeNull();
+  });
+
+  it("handles single value", () => {
+    const result = computeBoxPlotStats([42]);
+    expect(result).not.toBeNull();
+    expect(result!.min).toBe(42);
+    expect(result!.p5).toBe(42);
+    expect(result!.p25).toBe(42);
+    expect(result!.p50).toBe(42);
+    expect(result!.p75).toBe(42);
+    expect(result!.p95).toBe(42);
+    expect(result!.max).toBe(42);
+    expect(result!.values).toEqual([42]);
+  });
+
+  it("computes correct stats for known dataset", () => {
+    // 7 values (one per day of the week)
+    const values = [5000, 8000, 12000, 7500, 9000, 6000, 11000];
+    const result = computeBoxPlotStats(values)!;
+
+    // Sorted: [5000, 6000, 7500, 8000, 9000, 11000, 12000]
+    expect(result.min).toBe(5000);
+    expect(result.max).toBe(12000);
+    expect(result.p50).toBe(8000); // middle value of 7 elements
+
+    // p25: index = 0.25 * 6 = 1.5 → 6000 + 0.5 * (7500 - 6000) = 6750
+    expect(result.p25).toBe(6750);
+
+    // p75: index = 0.75 * 6 = 4.5 → 9000 + 0.5 * (11000 - 9000) = 10000
+    expect(result.p75).toBe(10000);
+
+    // values should be sorted
+    expect(result.values).toEqual([5000, 6000, 7500, 8000, 9000, 11000, 12000]);
+  });
+
+  it("filters out NaN and Infinity", () => {
+    const result = computeBoxPlotStats([10, NaN, 20, Infinity, 30]);
+    expect(result).not.toBeNull();
+    expect(result!.values).toEqual([10, 20, 30]);
+    expect(result!.p50).toBe(20);
+  });
+
+  it("rounds to 1 decimal place", () => {
+    const result = computeBoxPlotStats([1.15, 2.25, 3.35]);
+    expect(result).not.toBeNull();
+    // 1.15 rounds to 1.2, 2.25 rounds to 2.3, 3.35 rounds to 3.4
+    expect(result!.min).toBe(1.2);
+    expect(result!.max).toBe(3.4);
+  });
+
+  it("has correct shape with all fields", () => {
+    const result = computeBoxPlotStats([1, 2, 3, 4, 5]);
+    expect(result).toHaveProperty("min");
+    expect(result).toHaveProperty("p5");
+    expect(result).toHaveProperty("p25");
+    expect(result).toHaveProperty("p50");
+    expect(result).toHaveProperty("p75");
+    expect(result).toHaveProperty("p95");
+    expect(result).toHaveProperty("max");
+    expect(result).toHaveProperty("values");
+    expect(Array.isArray(result!.values)).toBe(true);
+  });
+
+  it("handles two values", () => {
+    const result = computeBoxPlotStats([10, 20])!;
+    expect(result.min).toBe(10);
+    expect(result.max).toBe(20);
+    expect(result.p50).toBe(15);
+  });
+
+  it("handles large dataset", () => {
+    // 100 values from 1 to 100
+    const values = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = computeBoxPlotStats(values)!;
+    expect(result.min).toBe(1);
+    expect(result.max).toBe(100);
+    expect(result.p50).toBe(50.5);
+    expect(result.p25).toBe(25.8); // 0.25 * 99 = 24.75 → 25 + 0.75*(26-25) = 25.75 → rounds to 25.8
+  });
+});
+
+// ─── extractValues ────────────────────────────────────────────────────────────
+
+describe("extractValues", () => {
+  it("returns empty array for empty input", () => {
+    expect(extractValues([])).toEqual([]);
+  });
+
+  it("filters out null values", () => {
+    const data = [
+      { value: 10 },
+      { value: null },
+      { value: 20 },
+      { value: null },
+      { value: 30 },
+    ];
+    expect(extractValues(data)).toEqual([10, 20, 30]);
+  });
+
+  it("returns all values when none are null", () => {
+    const data = [{ value: 1 }, { value: 2 }, { value: 3 }];
+    expect(extractValues(data)).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty array when all values are null", () => {
+    const data = [{ value: null }, { value: null }];
+    expect(extractValues(data)).toEqual([]);
+  });
+});

--- a/__tests__/summary.test.ts
+++ b/__tests__/summary.test.ts
@@ -8,6 +8,7 @@ function makeHealth(overrides: Partial<HealthData> = {}): HealthData {
     sleepHours: 7.2,
     bedtime: null,
     wakeTime: null,
+    sleepSamples: null,
     activeEnergy: 450,
     walkingDistance: 5.3,
     weight: null,

--- a/__tests__/summary.test.ts
+++ b/__tests__/summary.test.ts
@@ -8,7 +8,7 @@ function makeHealth(overrides: Partial<HealthData> = {}): HealthData {
     sleepHours: 7.2,
     bedtime: null,
     wakeTime: null,
-    sleepSamples: null,
+    sleepBySource: null,
     activeEnergy: 450,
     walkingDistance: 5.3,
     weight: null,

--- a/components/BoxPlot.tsx
+++ b/components/BoxPlot.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import type { BoxPlotStats } from "../lib/stats";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PLOT_HEIGHT = 24;
+const DOT_SIZE = 4;
+const DOT_ROW_HEIGHT = 10;
+const WHISKER_WIDTH = 1;
+const MEDIAN_WIDTH = 2;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+type Props = {
+  stats: BoxPlotStats;
+  color: string;
+};
+
+// ─── BoxPlot ──────────────────────────────────────────────────────────────────
+
+/**
+ * Horizontal box plot rendered with React Native Views.
+ *
+ * Layout (top to bottom):
+ *   1. Dot row: individual data points as small circles
+ *   2. Box plot: whiskers (p5–p25, p75–p95), box (p25–p75), median line (p50)
+ *
+ * All positions are computed as percentages of the full range (min–max).
+ */
+export default function BoxPlot({ stats, color }: Props): React.JSX.Element {
+  const { min, max, p5, p25, p50, p75, p95, values } = stats;
+  const range = max - min;
+
+  // When all values are identical, show a single centered bar.
+  if (range === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.dotRow}>
+          <View
+            style={[
+              styles.dot,
+              { backgroundColor: color, left: "50%" },
+            ]}
+          />
+        </View>
+        <View style={[styles.plotRow, { height: PLOT_HEIGHT }]}>
+          <View
+            style={[
+              styles.medianLine,
+              { backgroundColor: color, left: "50%" },
+            ]}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  // Convert a value to a percentage position within the range.
+  const toPercent = (v: number): number => ((v - min) / range) * 100;
+
+  const p5Pct = toPercent(p5);
+  const p25Pct = toPercent(p25);
+  const p50Pct = toPercent(p50);
+  const p75Pct = toPercent(p75);
+  const p95Pct = toPercent(p95);
+
+  const boxLeft = p25Pct;
+  const boxWidth = p75Pct - p25Pct;
+
+  // Dimmed color for whiskers and dots (30% opacity).
+  const dimColor = `${color}4D`;
+
+  return (
+    <View style={styles.container}>
+      {/* Dot row: individual data points */}
+      <View style={styles.dotRow}>
+        {values.map((v, i) => (
+          <View
+            key={i}
+            style={[
+              styles.dot,
+              {
+                backgroundColor: dimColor,
+                left: `${toPercent(v)}%`,
+              },
+            ]}
+          />
+        ))}
+      </View>
+
+      {/* Box plot row */}
+      <View style={[styles.plotRow, { height: PLOT_HEIGHT }]}>
+        {/* Left whisker: p5 to p25 */}
+        <View
+          style={[
+            styles.whisker,
+            {
+              backgroundColor: dimColor,
+              left: `${p5Pct}%`,
+              width: `${boxLeft - p5Pct}%`,
+            },
+          ]}
+        />
+
+        {/* Box: p25 to p75 */}
+        <View
+          style={[
+            styles.box,
+            {
+              backgroundColor: `${color}33`,
+              borderColor: color,
+              left: `${boxLeft}%`,
+              width: `${Math.max(boxWidth, 0.5)}%`,
+            },
+          ]}
+        />
+
+        {/* Right whisker: p75 to p95 */}
+        <View
+          style={[
+            styles.whisker,
+            {
+              backgroundColor: dimColor,
+              left: `${p75Pct}%`,
+              width: `${p95Pct - p75Pct}%`,
+            },
+          ]}
+        />
+
+        {/* Median line */}
+        <View
+          style={[
+            styles.medianLine,
+            {
+              backgroundColor: color,
+              left: `${p50Pct}%`,
+            },
+          ]}
+        />
+      </View>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    marginTop: 6,
+  },
+  dotRow: {
+    height: DOT_ROW_HEIGHT,
+    position: "relative",
+  },
+  dot: {
+    position: "absolute",
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    top: (DOT_ROW_HEIGHT - DOT_SIZE) / 2,
+    marginLeft: -(DOT_SIZE / 2),
+  },
+  plotRow: {
+    position: "relative",
+  },
+  whisker: {
+    position: "absolute",
+    height: WHISKER_WIDTH,
+    top: (PLOT_HEIGHT - WHISKER_WIDTH) / 2,
+  },
+  box: {
+    position: "absolute",
+    top: 2,
+    bottom: 2,
+    borderWidth: 1,
+    borderRadius: 4,
+  },
+  medianLine: {
+    position: "absolute",
+    width: MEDIAN_WIDTH,
+    top: 0,
+    bottom: 0,
+    borderRadius: 1,
+    marginLeft: -(MEDIAN_WIDTH / 2),
+  },
+});

--- a/components/MetricDetailSheet.tsx
+++ b/components/MetricDetailSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Animated,
   Dimensions,
@@ -80,6 +80,7 @@ function formatDailyValue(item: DailyValue, unit: string): string {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
+/** Format UTC ISO timestamp as local 12-hour time (intentional: users see sleep times in their timezone). */
 function formatSleepTime(iso: string): string {
   const d = new Date(iso);
   const h = d.getHours();
@@ -100,10 +101,18 @@ export default function MetricDetailSheet({
 }: MetricDetailSheetProps): React.ReactElement {
   const screenHeight = Dimensions.get("window").height;
   const config = METRIC_CONFIG[metricKey];
-  const sourceNames = sleepBySource ? Object.keys(sleepBySource) : [];
-  const [selectedSource, setSelectedSource] = useState<string | null>(
-    sourceNames[0] ?? null,
+  const sourceNames = useMemo(
+    () => (sleepBySource ? Object.keys(sleepBySource) : []),
+    [sleepBySource],
   );
+  const [selectedSource, setSelectedSource] = useState<string | null>(null);
+
+  // Update selected source when sleepBySource data arrives
+  useEffect(() => {
+    if (sourceNames.length > 0 && selectedSource === null) {
+      setSelectedSource(sourceNames[0]);
+    }
+  }, [sourceNames, selectedSource]);
 
   // Single animated value drives translateY (0 = visible) and overlay opacity.
   const animValue = useRef(new Animated.Value(0)).current;

--- a/components/MetricDetailSheet.tsx
+++ b/components/MetricDetailSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Animated,
   Dimensions,
@@ -7,10 +7,12 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TouchableOpacity,
   TouchableWithoutFeedback,
   View,
   ActivityIndicator,
 } from "react-native";
+import type { SourceSleepSummary } from "../lib/health";
 import {
   METRIC_CONFIG,
   computeAverage,
@@ -31,6 +33,7 @@ type MetricDetailSheetProps = {
   data: DailyValue[] | HeartRateDaily[] | null; // null = loading
   error: string | null;
   onClose: () => void;
+  sleepBySource?: Record<string, SourceSleepSummary> | null;
 };
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -77,6 +80,15 @@ function formatDailyValue(item: DailyValue, unit: string): string {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
+function formatSleepTime(iso: string): string {
+  const d = new Date(iso);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h >= 12 ? "PM" : "AM";
+  const h12 = h % 12 || 12;
+  return `${h12}:${m.toString().padStart(2, "0")} ${ampm}`;
+}
+
 export default function MetricDetailSheet({
   metricKey,
   currentValue,
@@ -84,9 +96,14 @@ export default function MetricDetailSheet({
   data,
   error,
   onClose,
+  sleepBySource,
 }: MetricDetailSheetProps): React.ReactElement {
   const screenHeight = Dimensions.get("window").height;
   const config = METRIC_CONFIG[metricKey];
+  const sourceNames = sleepBySource ? Object.keys(sleepBySource) : [];
+  const [selectedSource, setSelectedSource] = useState<string | null>(
+    sourceNames[0] ?? null,
+  );
 
   // Single animated value drives translateY (0 = visible) and overlay opacity.
   const animValue = useRef(new Animated.Value(0)).current;
@@ -275,6 +292,44 @@ export default function MetricDetailSheet({
             <Text style={styles.currentSublabel}>{currentSublabel}</Text>
           </View>
 
+          {/* Sleep source tabs */}
+          {metricKey === "sleep" && sourceNames.length > 0 && (
+            <View style={styles.sourceSection}>
+              <View style={styles.sourceTabs}>
+                {sourceNames.map((name) => (
+                  <TouchableOpacity
+                    key={name}
+                    style={[
+                      styles.sourceTab,
+                      selectedSource === name && { backgroundColor: config.color + "33", borderColor: config.color },
+                    ]}
+                    onPress={() => setSelectedSource(name)}
+                  >
+                    <Text style={[styles.sourceTabText, selectedSource === name && { color: config.color }]}>
+                      {name}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+              {selectedSource && sleepBySource?.[selectedSource] && (() => {
+                const s = sleepBySource[selectedSource];
+                return (
+                  <View style={styles.sourceDetail}>
+                    <Text style={styles.sourceDetailRow}>
+                      {formatSleepTime(s.bedtime)} → {formatSleepTime(s.wakeTime)}
+                    </Text>
+                    <View style={styles.stageRow}>
+                      {s.deepHours > 0 && <Text style={styles.stagePill}>Deep {s.deepHours}h</Text>}
+                      {s.coreHours > 0 && <Text style={styles.stagePill}>Core {s.coreHours}h</Text>}
+                      {s.remHours > 0 && <Text style={styles.stagePill}>REM {s.remHours}h</Text>}
+                      {s.awakeHours > 0 && <Text style={[styles.stagePill, { color: "#f4845f" }]}>Awake {s.awakeHours}h</Text>}
+                    </View>
+                  </View>
+                );
+              })()}
+            </View>
+          )}
+
           {/* Chart */}
           <View style={styles.chartContainer}>{chartContent}</View>
 
@@ -407,5 +462,48 @@ const styles = StyleSheet.create({
   dayRowValue: {
     fontSize: 15,
     color: "#aaa",
+  },
+  sourceSection: {
+    paddingHorizontal: 20,
+    paddingBottom: 12,
+  },
+  sourceTabs: {
+    flexDirection: "row",
+    gap: 8,
+    marginBottom: 10,
+  },
+  sourceTab: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#333",
+  },
+  sourceTabText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#888",
+  },
+  sourceDetail: {
+    paddingVertical: 4,
+  },
+  sourceDetailRow: {
+    fontSize: 15,
+    color: "#e0e0e0",
+    marginBottom: 8,
+  },
+  stageRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  stagePill: {
+    fontSize: 13,
+    color: "#aaa",
+    backgroundColor: "#222",
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    overflow: "hidden",
   },
 });

--- a/lib/clustering.ts
+++ b/lib/clustering.ts
@@ -4,6 +4,8 @@
  * Pure functions — no device access, fully testable.
  */
 
+import { type KnownPlace, labelPointsWithKnownPlaces, buildKnownPlaceClusters } from "./places";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type LocationPoint = {
@@ -355,50 +357,100 @@ export function downsample(points: LocationPoint[], maxPoints = MAX_CLUSTER_POIN
 
 /**
  * Cluster location history into places.
- * Uses grid-based union-find: O(n) complexity.
+ * When knownPlaces are provided, GPS points are matched against them first
+ * (by distance within configured radius). Unmatched points fall through to
+ * generic grid-based clustering.
+ *
  * @param points Raw GPS points from SQLite
- * @param epsMeters Distance threshold (default 50m)
+ * @param epsMeters Distance threshold for generic clustering (default 50m)
  * @param minPts Minimum points per cluster (default 3)
+ * @param knownPlaces Optional array of user-defined known places
  */
 export function clusterLocations(
   points: LocationPoint[],
   epsMeters = 50,
   minPts = 3,
+  knownPlaces: KnownPlace[] = [],
 ): ClusterResult {
   if (points.length === 0) {
     return { clusters: [], timeline: [], noiseCount: 0, summary: "" };
   }
 
-  const labels = dbscan(points, epsMeters, minPts);
+  // Step 1: Match points against known places
+  const knownLabels = knownPlaces.length > 0
+    ? labelPointsWithKnownPlaces(points, knownPlaces)
+    : points.map(() => -1);
 
-  // Group points by cluster label
+  // Separate matched and unmatched points
+  const unmatchedPoints: LocationPoint[] = [];
+  const unmatchedOriginalIndices: number[] = [];
+  for (let i = 0; i < points.length; i++) {
+    if (knownLabels[i] === -1) {
+      unmatchedPoints.push(points[i]);
+      unmatchedOriginalIndices.push(i);
+    }
+  }
+
+  // Step 2: Run generic clustering on unmatched points only
+  const genericLabels = unmatchedPoints.length > 0
+    ? dbscan(unmatchedPoints, epsMeters, minPts)
+    : [];
+
+  // Group unmatched points by cluster label
   const groups = new Map<number, LocationPoint[]>();
   let noiseCount = 0;
 
-  for (let i = 0; i < labels.length; i++) {
-    if (labels[i] === -1) {
+  for (let i = 0; i < genericLabels.length; i++) {
+    if (genericLabels[i] === -1) {
       noiseCount++;
       continue;
     }
-    if (!groups.has(labels[i])) groups.set(labels[i], []);
-    groups.get(labels[i])!.push(points[i]);
+    if (!groups.has(genericLabels[i])) groups.set(genericLabels[i], []);
+    groups.get(genericLabels[i])!.push(unmatchedPoints[i]);
   }
 
-  // Build clusters, sorted by dwell time descending
-  const clusters: PlaceCluster[] = [];
+  // Build generic clusters with "place_N" IDs
+  const genericClusters: PlaceCluster[] = [];
   let cIdx = 1;
   for (const [, cPoints] of groups) {
-    clusters.push(buildCluster(`place_${cIdx++}`, cPoints));
+    genericClusters.push(buildCluster(`place_${cIdx++}`, cPoints));
   }
-  clusters.sort((a, b) => b.dwellTimeHours - a.dwellTimeHours);
+  genericClusters.sort((a, b) => b.dwellTimeHours - a.dwellTimeHours);
+  genericClusters.forEach((c, i) => { c.id = `place_${i + 1}`; });
 
-  // Renumber IDs after sorting
-  clusters.forEach((c, i) => { c.id = `place_${i + 1}`; });
+  // Step 3: Build known place clusters
+  const knownClusters = knownPlaces.length > 0
+    ? buildKnownPlaceClusters(points, knownLabels, knownPlaces)
+    : [];
 
-  const timeline = buildTimeline(points, labels, clusters);
+  // Combine: known place clusters first, then generic
+  const allClusters = [...knownClusters, ...genericClusters];
+
+  // Step 4: Build combined labels for timeline
+  // We need a single label array across all points that maps to allClusters
+  // Use negative numbers offset for known place clusters to avoid collision with generic labels
+  const KNOWN_LABEL_OFFSET = 1000000; // large offset to avoid collision
+  const combinedLabels: number[] = new Array(points.length);
+
+  for (let i = 0; i < points.length; i++) {
+    if (knownLabels[i] !== -1) {
+      // Point matched a known place — use offset label
+      combinedLabels[i] = KNOWN_LABEL_OFFSET + knownLabels[i];
+    } else {
+      // Find this point's index in unmatchedPoints
+      const unmatchedIdx = unmatchedOriginalIndices.indexOf(i);
+      if (unmatchedIdx !== -1 && genericLabels[unmatchedIdx] !== -1) {
+        combinedLabels[i] = genericLabels[unmatchedIdx];
+      } else {
+        combinedLabels[i] = -1;
+      }
+    }
+  }
+
+  const timeline = buildTimeline(points, combinedLabels, allClusters);
   const summary = formatTimelineSummary(timeline);
 
-  return { clusters, timeline, noiseCount, summary };
+  return { clusters: allClusters, timeline, noiseCount, summary };
 }
 
 // ─── Summary Formatting ──────────────────────────────────────────────────────

--- a/lib/clustering.ts
+++ b/lib/clustering.ts
@@ -42,22 +42,10 @@ export type ClusterResult = {
 
 // ─── Haversine Distance ──────────────────────────────────────────────────────
 
-const DEG_TO_RAD = Math.PI / 180;
-const EARTH_RADIUS_M = 6371000;
+export { haversineDistance } from "./geo";
+import { haversineDistance } from "./geo";
 
-/** Haversine distance between two lat/lng points in meters. */
-export function haversineDistance(
-  lat1: number, lng1: number,
-  lat2: number, lng2: number,
-): number {
-  const dLat = (lat2 - lat1) * DEG_TO_RAD;
-  const dLng = (lng2 - lng1) * DEG_TO_RAD;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(lat1 * DEG_TO_RAD) * Math.cos(lat2 * DEG_TO_RAD) *
-    Math.sin(dLng / 2) ** 2;
-  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a));
-}
+const DEG_TO_RAD = Math.PI / 180;
 
 // ─── Union-Find ──────────────────────────────────────────────────────────────
 
@@ -432,13 +420,18 @@ export function clusterLocations(
   const KNOWN_LABEL_OFFSET = 1000000; // large offset to avoid collision
   const combinedLabels: number[] = new Array(points.length);
 
+  // Build reverse lookup: original index → unmatched index (O(n) instead of O(n^2))
+  const originalToUnmatched = new Map<number, number>();
+  for (let i = 0; i < unmatchedOriginalIndices.length; i++) {
+    originalToUnmatched.set(unmatchedOriginalIndices[i], i);
+  }
+
   for (let i = 0; i < points.length; i++) {
     if (knownLabels[i] !== -1) {
       // Point matched a known place — use offset label
       combinedLabels[i] = KNOWN_LABEL_OFFSET + knownLabels[i];
     } else {
-      // Find this point's index in unmatchedPoints
-      const unmatchedIdx = unmatchedOriginalIndices.indexOf(i);
+      const unmatchedIdx = originalToUnmatched.get(i) ?? -1;
       if (unmatchedIdx !== -1 && genericLabels[unmatchedIdx] !== -1) {
         combinedLabels[i] = genericLabels[unmatchedIdx];
       } else {

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared geographic utility functions.
+ */
+
+const DEG_TO_RAD = Math.PI / 180;
+const EARTH_RADIUS_M = 6371000;
+
+/** Haversine distance between two lat/lng points in meters. */
+export function haversineDistance(
+  lat1: number, lng1: number,
+  lat2: number, lng2: number,
+): number {
+  const dLat = (lat2 - lat1) * DEG_TO_RAD;
+  const dLng = (lng2 - lng1) * DEG_TO_RAD;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * DEG_TO_RAD) * Math.cos(lat2 * DEG_TO_RAD) *
+    Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a));
+}

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -5,10 +5,13 @@
 
 import { extractSleepDetails } from "./sleep";
 
-export type RawSleepSample = {
-  startDate: string; // ISO 8601 UTC
-  endDate: string;   // ISO 8601 UTC
-  category: string;  // "InBed", "Asleep", "Awake", "Core", "Deep", "REM"
+export type SourceSleepSummary = {
+  bedtime: string;   // ISO 8601 UTC
+  wakeTime: string;  // ISO 8601 UTC
+  coreHours: number;
+  deepHours: number;
+  remHours: number;
+  awakeHours: number;
 };
 
 export type HealthData = {
@@ -17,7 +20,7 @@ export type HealthData = {
   sleepHours: number | null;
   bedtime: string | null;
   wakeTime: string | null;
-  sleepSamples: RawSleepSample[] | null;
+  sleepBySource: Record<string, SourceSleepSummary> | null;
   activeEnergy: number | null;
   walkingDistance: number | null;
   weight: number | null;
@@ -54,6 +57,7 @@ export type SleepSample = {
   startDate: string | Date;
   endDate: string | Date;
   value?: number; // 0=InBed, 1=Asleep, 2=Awake, 3=Core, 4=Deep, 5=REM
+  source?: string; // e.g. "Apple Watch", "AutoSleep"
 };
 
 // Sleep values that count as actual sleep (exclude InBed=0 and Awake=2)
@@ -78,22 +82,63 @@ export function sleepCategoryName(value: number | undefined): string {
   return SLEEP_CATEGORY_NAMES[value] ?? "Unknown";
 }
 
+// Stage value to hours-field mapping
+const STAGE_HOURS_KEY: Record<number, keyof Pick<SourceSleepSummary, "coreHours" | "deepHours" | "remHours" | "awakeHours">> = {
+  2: "awakeHours",
+  3: "coreHours",
+  4: "deepHours",
+  5: "remHours",
+};
+
 /**
- * Convert raw HealthKit sleep samples to the export format.
+ * Build a per-source sleep summary from HealthKit samples.
+ * Groups samples by source, computes bedtime/wakeTime and hours per stage.
  * Returns null if samples is empty or undefined.
- * Samples are sorted by startDate ascending, with ISO 8601 UTC timestamps.
  */
-export function formatSleepSamples(
+export function buildSleepBySource(
   samples: SleepSample[] | undefined,
-): RawSleepSample[] | null {
+): Record<string, SourceSleepSummary> | null {
   if (!samples || samples.length === 0) return null;
-  return [...samples]
-    .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
-    .map((s) => ({
-      startDate: new Date(s.startDate).toISOString(),
-      endDate: new Date(s.endDate).toISOString(),
-      category: sleepCategoryName(s.value),
-    }));
+
+  const bySource = new Map<string, SleepSample[]>();
+  for (const s of samples) {
+    const src = s.source ?? "Unknown";
+    const arr = bySource.get(src);
+    if (arr) arr.push(s);
+    else bySource.set(src, [s]);
+  }
+
+  const result: Record<string, SourceSleepSummary> = {};
+  for (const [source, sourceSamples] of bySource) {
+    const sorted = [...sourceSamples].sort(
+      (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+    );
+
+    const bedtime = new Date(sorted[0].startDate).toISOString();
+    const wakeTime = new Date(sorted[sorted.length - 1].endDate).toISOString();
+
+    const summary: SourceSleepSummary = { bedtime, wakeTime, coreHours: 0, deepHours: 0, remHours: 0, awakeHours: 0 };
+
+    for (const s of sorted) {
+      const ms = Math.max(0, new Date(s.endDate).getTime() - new Date(s.startDate).getTime());
+      const hours = ms / (1000 * 60 * 60);
+      const key = s.value !== undefined ? STAGE_HOURS_KEY[s.value] : undefined;
+      if (key) {
+        summary[key] += hours;
+      }
+      // InBed (0), Asleep (1), and unknown values don't get their own bucket
+    }
+
+    // Round to 1 decimal
+    summary.coreHours = Math.round(summary.coreHours * 10) / 10;
+    summary.deepHours = Math.round(summary.deepHours * 10) / 10;
+    summary.remHours = Math.round(summary.remHours * 10) / 10;
+    summary.awakeHours = Math.round(summary.awakeHours * 10) / 10;
+
+    result[source] = summary;
+  }
+
+  return result;
 }
 
 /**
@@ -224,7 +269,7 @@ export function buildHealthData(results: HealthQueryResults): HealthData {
     sleepHours,
     bedtime: sleepDetails.bedtime,
     wakeTime: sleepDetails.wakeTime,
-    sleepSamples: formatSleepSamples(rawSleepSamples),
+    sleepBySource: buildSleepBySource(rawSleepSamples),
     activeEnergy:
       activeEnergy.status === "fulfilled" && activeEnergy.value.sumQuantity?.quantity != null
         ? Math.round(activeEnergy.value.sumQuantity.quantity)

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -5,12 +5,19 @@
 
 import { extractSleepDetails } from "./sleep";
 
+export type RawSleepSample = {
+  startDate: string; // ISO 8601 UTC
+  endDate: string;   // ISO 8601 UTC
+  category: string;  // "InBed", "Asleep", "Awake", "Core", "Deep", "REM"
+};
+
 export type HealthData = {
   steps: number | null;
   heartRate: number | null;
   sleepHours: number | null;
   bedtime: string | null;
   wakeTime: string | null;
+  sleepSamples: RawSleepSample[] | null;
   activeEnergy: number | null;
   walkingDistance: number | null;
   weight: number | null;
@@ -51,6 +58,43 @@ export type SleepSample = {
 
 // Sleep values that count as actual sleep (exclude InBed=0 and Awake=2)
 const SLEEP_VALUES = new Set([1, 3, 4, 5]);
+
+// Map HealthKit sleep value to readable category name
+const SLEEP_CATEGORY_NAMES: Record<number, string> = {
+  0: "InBed",
+  1: "Asleep",
+  2: "Awake",
+  3: "Core",
+  4: "Deep",
+  5: "REM",
+};
+
+/**
+ * Map a HealthKit sleep value number to a readable category name.
+ * Returns "Unknown" for unrecognized values.
+ */
+export function sleepCategoryName(value: number | undefined): string {
+  if (value === undefined) return "Asleep";
+  return SLEEP_CATEGORY_NAMES[value] ?? "Unknown";
+}
+
+/**
+ * Convert raw HealthKit sleep samples to the export format.
+ * Returns null if samples is empty or undefined.
+ * Samples are sorted by startDate ascending, with ISO 8601 UTC timestamps.
+ */
+export function formatSleepSamples(
+  samples: SleepSample[] | undefined,
+): RawSleepSample[] | null {
+  if (!samples || samples.length === 0) return null;
+  return [...samples]
+    .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+    .map((s) => ({
+      startDate: new Date(s.startDate).toISOString(),
+      endDate: new Date(s.endDate).toISOString(),
+      category: sleepCategoryName(s.value),
+    }));
+}
 
 /**
  * Filter sleep samples to only actual sleep (not InBed or Awake).
@@ -163,10 +207,10 @@ export type HealthQueryResults = [
 export function buildHealthData(results: HealthQueryResults): HealthData {
   const [steps, heartRate, activeEnergy, walkingDistance, sleep, weight, meditation, weightSamples, hrv, restingHeartRate, exerciseTime] = results;
 
-  const sleepSamples =
+  const rawSleepSamples =
     sleep.status === "fulfilled" ? sleep.value : undefined;
-  const sleepHours = calculateSleepHours(sleepSamples);
-  const sleepDetails = extractSleepDetails(sleepSamples);
+  const sleepHours = calculateSleepHours(rawSleepSamples);
+  const sleepDetails = extractSleepDetails(rawSleepSamples);
 
   return {
     steps:
@@ -180,6 +224,7 @@ export function buildHealthData(results: HealthQueryResults): HealthData {
     sleepHours,
     bedtime: sleepDetails.bedtime,
     wakeTime: sleepDetails.wakeTime,
+    sleepSamples: formatSleepSamples(rawSleepSamples),
     activeEnergy:
       activeEnergy.status === "fulfilled" && activeEnergy.value.sumQuantity?.quantity != null
         ? Math.round(activeEnergy.value.sumQuantity.quantity)

--- a/lib/places.ts
+++ b/lib/places.ts
@@ -4,25 +4,7 @@
  */
 
 import type { LocationPoint, PlaceCluster } from "./clustering";
-
-// ─── Haversine Distance (local copy to avoid circular dependency) ────────────
-
-const DEG_TO_RAD = Math.PI / 180;
-const EARTH_RADIUS_M = 6371000;
-
-/** Haversine distance between two lat/lng points in meters. */
-export function haversineDistancePlaces(
-  lat1: number, lng1: number,
-  lat2: number, lng2: number,
-): number {
-  const dLat = (lat2 - lat1) * DEG_TO_RAD;
-  const dLng = (lng2 - lng1) * DEG_TO_RAD;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(lat1 * DEG_TO_RAD) * Math.cos(lat2 * DEG_TO_RAD) *
-    Math.sin(dLng / 2) ** 2;
-  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a));
-}
+import { haversineDistance } from "./geo";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -56,7 +38,7 @@ export function matchPointToPlace(
 
   for (let i = 0; i < knownPlaces.length; i++) {
     const place = knownPlaces[i];
-    const dist = haversineDistancePlaces(lat, lng, place.latitude, place.longitude);
+    const dist = haversineDistance(lat, lng, place.latitude, place.longitude);
     if (dist <= place.radiusMeters && dist < bestDistance) {
       bestIndex = i;
       bestDistance = dist;

--- a/lib/places.ts
+++ b/lib/places.ts
@@ -1,0 +1,127 @@
+/**
+ * Known-places matching logic.
+ * Pure functions — no device access, fully testable.
+ */
+
+import type { LocationPoint, PlaceCluster } from "./clustering";
+
+// ─── Haversine Distance (local copy to avoid circular dependency) ────────────
+
+const DEG_TO_RAD = Math.PI / 180;
+const EARTH_RADIUS_M = 6371000;
+
+/** Haversine distance between two lat/lng points in meters. */
+export function haversineDistancePlaces(
+  lat1: number, lng1: number,
+  lat2: number, lng2: number,
+): number {
+  const dLat = (lat2 - lat1) * DEG_TO_RAD;
+  const dLng = (lng2 - lng1) * DEG_TO_RAD;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * DEG_TO_RAD) * Math.cos(lat2 * DEG_TO_RAD) *
+    Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a));
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type KnownPlace = {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  radiusMeters: number;
+};
+
+export type MatchResult = {
+  placeIndex: number; // index into KnownPlace[], or -1 if no match
+  distance: number; // distance in meters to the matched place (Infinity if no match)
+};
+
+// ─── Matching ────────────────────────────────────────────────────────────────
+
+/**
+ * Find the closest known place within radius for a single GPS point.
+ * Returns the index into the knownPlaces array and the distance.
+ * If no place is within radius, returns { placeIndex: -1, distance: Infinity }.
+ */
+export function matchPointToPlace(
+  lat: number,
+  lng: number,
+  knownPlaces: KnownPlace[],
+): MatchResult {
+  let bestIndex = -1;
+  let bestDistance = Infinity;
+
+  for (let i = 0; i < knownPlaces.length; i++) {
+    const place = knownPlaces[i];
+    const dist = haversineDistancePlaces(lat, lng, place.latitude, place.longitude);
+    if (dist <= place.radiusMeters && dist < bestDistance) {
+      bestIndex = i;
+      bestDistance = dist;
+    }
+  }
+
+  return { placeIndex: bestIndex, distance: bestDistance };
+}
+
+/**
+ * Label each GPS point: match against known places first.
+ * Returns an array of KnownPlace indices (-1 for unmatched points).
+ */
+export function labelPointsWithKnownPlaces(
+  points: LocationPoint[],
+  knownPlaces: KnownPlace[],
+): number[] {
+  return points.map((p) =>
+    matchPointToPlace(p.latitude, p.longitude, knownPlaces).placeIndex,
+  );
+}
+
+/**
+ * Build PlaceCluster objects from points matched to known places.
+ * Groups points by their known place match, computes dwell time.
+ */
+export function buildKnownPlaceClusters(
+  points: LocationPoint[],
+  knownPlaceLabels: number[],
+  knownPlaces: KnownPlace[],
+): PlaceCluster[] {
+  const groups = new Map<number, LocationPoint[]>();
+
+  for (let i = 0; i < points.length; i++) {
+    const label = knownPlaceLabels[i];
+    if (label === -1) continue;
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label)!.push(points[i]);
+  }
+
+  const clusters: PlaceCluster[] = [];
+  for (const [placeIdx, pts] of groups) {
+    const place = knownPlaces[placeIdx];
+    const timestamps = pts.map((p) => p.timestamp).sort((a, b) => a - b);
+    const firstVisit = timestamps[0];
+    const lastVisit = timestamps[timestamps.length - 1];
+
+    // Estimate dwell time: sum gaps between consecutive points (capped at 2hrs per gap)
+    const MAX_GAP_MS = 2 * 60 * 60 * 1000;
+    let dwellMs = 0;
+    for (let i = 1; i < timestamps.length; i++) {
+      const gap = timestamps[i] - timestamps[i - 1];
+      dwellMs += Math.min(gap, MAX_GAP_MS);
+    }
+
+    clusters.push({
+      id: place.name,
+      center: { latitude: place.latitude, longitude: place.longitude },
+      radiusMeters: place.radiusMeters,
+      pointCount: pts.length,
+      dwellTimeHours: Math.round((dwellMs / (1000 * 60 * 60)) * 10) / 10,
+      firstVisit,
+      lastVisit,
+    });
+  }
+
+  return clusters;
+}

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -5,6 +5,7 @@
 
 import type { DailyValue, HeartRateDaily } from "./weekly";
 import type { PlaceCluster, PlaceVisit } from "./clustering";
+import { computeBoxPlotStats, extractValues, type BoxPlotStats } from "./stats";
 
 export type DailyExportEntry = {
   date: string; // "YYYY-MM-DD"
@@ -27,8 +28,33 @@ export type LocationSummary = {
   summary: string;
 };
 
+/** Statistical summary for a single metric (omits the raw values array for brevity). */
+export type MetricStatsExport = {
+  min: number;
+  p5: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p95: number;
+  max: number;
+};
+
+export type WeeklyStatsExport = {
+  steps: MetricStatsExport | null;
+  heartRate: MetricStatsExport | null;
+  sleepHours: MetricStatsExport | null;
+  activeEnergy: MetricStatsExport | null;
+  walkingDistanceKm: MetricStatsExport | null;
+  weightKg: MetricStatsExport | null;
+  meditationMinutes: MetricStatsExport | null;
+  hrvMs: MetricStatsExport | null;
+  restingHeartRate: MetricStatsExport | null;
+  exerciseMinutes: MetricStatsExport | null;
+};
+
 export type SummaryExport = {
   days: DailyExportEntry[];
+  weeklyStats: WeeklyStatsExport;
   locationSummary: LocationSummary | null;
 };
 
@@ -66,11 +92,45 @@ export type WeeklyDataMap = {
 };
 
 /**
- * Build an array of 7 daily export entries from weekly metric data.
- * Each entry combines all metrics for that day.
+ * Convert BoxPlotStats to the leaner export format (drops raw values array).
  */
+function toStatsExport(stats: BoxPlotStats | null): MetricStatsExport | null {
+  if (!stats) return null;
+  return {
+    min: stats.min,
+    p5: stats.p5,
+    p25: stats.p25,
+    p50: stats.p50,
+    p75: stats.p75,
+    p95: stats.p95,
+    max: stats.max,
+  };
+}
+
 /**
- * Build a summary export: 7-day daily health data + location clusters.
+ * Compute 7-day statistical summaries for all metrics.
+ */
+export function buildWeeklyStats(data: WeeklyDataMap): WeeklyStatsExport {
+  const hrValues = (data.heartRate as HeartRateDaily[])
+    .filter((d) => d.avg !== null)
+    .map((d) => d.avg as number);
+
+  return {
+    steps: toStatsExport(computeBoxPlotStats(extractValues(data.steps))),
+    heartRate: toStatsExport(computeBoxPlotStats(hrValues)),
+    sleepHours: toStatsExport(computeBoxPlotStats(extractValues(data.sleep))),
+    activeEnergy: toStatsExport(computeBoxPlotStats(extractValues(data.activeEnergy))),
+    walkingDistanceKm: toStatsExport(computeBoxPlotStats(extractValues(data.walkingDistance))),
+    weightKg: toStatsExport(computeBoxPlotStats(extractValues(data.weight))),
+    meditationMinutes: toStatsExport(computeBoxPlotStats(extractValues(data.meditation))),
+    hrvMs: toStatsExport(computeBoxPlotStats(extractValues(data.hrv))),
+    restingHeartRate: toStatsExport(computeBoxPlotStats(extractValues(data.restingHeartRate))),
+    exerciseMinutes: toStatsExport(computeBoxPlotStats(extractValues(data.exerciseMinutes))),
+  };
+}
+
+/**
+ * Build a summary export: 7-day daily health data + stats + location clusters.
  */
 export function buildSummaryExport(
   data: WeeklyDataMap,
@@ -78,6 +138,7 @@ export function buildSummaryExport(
 ): SummaryExport {
   return {
     days: buildDailyExport(data),
+    weeklyStats: buildWeeklyStats(data),
     locationSummary,
   };
 }

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure statistical functions for computing percentiles and box plot summaries.
+ * No device or HealthKit access — fully testable.
+ */
+
+export type BoxPlotStats = {
+  min: number;
+  p5: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p95: number;
+  max: number;
+  values: number[];
+};
+
+/**
+ * Compute a percentile value from a sorted array using linear interpolation.
+ * @param sorted  Pre-sorted array of numbers (ascending).
+ * @param p       Percentile as a fraction (0–1), e.g. 0.5 for p50.
+ */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) throw new Error("Cannot compute percentile of empty array");
+  if (sorted.length === 1) return sorted[0];
+
+  // Use the "exclusive" (R-7) interpolation method, matching NumPy/Excel default.
+  const index = p * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+
+  if (lower === upper) return sorted[lower];
+
+  const fraction = index - lower;
+  return sorted[lower] + fraction * (sorted[upper] - sorted[lower]);
+}
+
+/**
+ * Compute box plot statistics from an array of numbers.
+ * Returns null if the input array is empty or contains no finite values.
+ * Values are rounded to 1 decimal place for display.
+ */
+export function computeBoxPlotStats(values: number[]): BoxPlotStats | null {
+  // Filter to finite numbers only.
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length === 0) return null;
+
+  const sorted = [...finite].sort((a, b) => a - b);
+
+  return {
+    min: round1(sorted[0]),
+    p5: round1(percentile(sorted, 0.05)),
+    p25: round1(percentile(sorted, 0.25)),
+    p50: round1(percentile(sorted, 0.5)),
+    p75: round1(percentile(sorted, 0.75)),
+    p95: round1(percentile(sorted, 0.95)),
+    max: round1(sorted[sorted.length - 1]),
+    values: sorted.map(round1),
+  };
+}
+
+/**
+ * Round to 1 decimal place.
+ */
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Extract non-null values from a DailyValue array for stats computation.
+ */
+export function extractValues(data: Array<{ value: number | null }>): number[] {
+  return data.filter((d) => d.value !== null).map((d) => d.value as number);
+}


### PR DESCRIPTION
## Summary

- **Box plot stats (#10)**: Compute p5/p25/p50/p75/p95 for weekly metric data. Horizontal box-and-whisker visualization in metric cards using pure RN Views. Stats included in share export.
- **Known places (#12)**: Configurable places stored in SQLite with radius-based GPS matching. Falls back to generic clustering for unmatched points. Settings UI with manual entry + JSON import for bulk setup.
- **Sleep per-source summary (#11)**: Compact `sleepBySource` in export with bedtime, wakeTime, and stage hours (core/deep/REM/awake) grouped by source app. Source tabs in sleep detail sheet to toggle between Apple Watch, AutoSleep, etc.

**14 files changed, +1,762 lines, 213 tests passing.**

## Test plan

- [ ] `npx jest` — all 213 tests pass
- [ ] Deploy to device, verify box plots render on metric card expansion
- [ ] Add known places via JSON import, verify they appear in location timeline export
- [ ] Verify sleep detail sheet shows source tabs with stage breakdown
- [ ] Confirm share export includes `sleepBySource` and `weeklyStats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage known places with persistent storage: add, import, and delete locations; view in Settings.
  * Metric cards can show box-plot visualizations to reveal data distributions.
  * Sleep details per source: per-source bedtime/wake times and stage breakdowns in metric detail view.
  * Weekly statistics included in summary/export with percentile-based summaries.

* **Tests**
  * Expanded test coverage for places clustering, statistics, sleep-by-source, and sharing/export logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->