### PR TITLE
docs: JTBD v2.2 — two-way mirror, two dragons

### DIFF
--- a/docs/jtbd.md
+++ b/docs/jtbd.md
@@ -1,0 +1,198 @@
+---
+date: 2026-05-26
+version: "2.2"
+title: Context Grabber JTBD — two-way mirror, two dragons
+sources:
+  - https://idvork.in/eulogy
+  - https://idvork.in/gap-year-igor
+status: living vision doc — overwrite in place; git log preserves history
+---
+
+CONTEXT GRABBER jobs-to-be-done · v2.2 · two-way mirror, two dragons
+May 2026 · for Igor
+derived from idvork.in/eulogy + idvork.in/gap-year-igor
+one-pager, print at 11×17
+The product, in one sentence
+A humane mirror
+that holds the long arc —
+so you can face your dragons
+before they grow.
+Not a fitness tracker. Not a habit tracker. Not a journal app. The eulogy is who you want to be. The app shows who you've actually been. The delta is the work — and the two dragons that guard it (Entropy and Squander) don't get defeated, they get named, watched, and slowly tamed.
+
+Primary job · hold up the mirror
+When I sit down with Larry, my therapist, or my own Sunday-morning self—
+I want a mirror that shows who I've actually been being the last week, without flinching and without judging—
+so I can see the delta from who I want to be, and act on it before the dragons grow.
+
+Hired by: the eulogy version of me
+Fired by: recency bias · vibes · "I think I went to the gym?"
+Success: the mirror shows something true I'd have missed
+Looking back · the mirror
+Show me who I've actually been being — without flinching, without judging.
+5am. Sunday review. Pre-Larry call. Fit fellow loud. Husband to Tori quiet. Father to Amelia missing the arboretum walk. The mirror is passive: it shows what's there, not what I want to see, not what an algorithm thinks I should improve. Mirrors don't suggest — but the way I see myself changes what I do next.
+
+Voice · grandmother mind · time-since, never streak-broken
+Looking forward · the whisper
+Remind me to be me at my best — quietly, in my own voice, every morning.
+The eulogy is the compass. Each morning the app whispers back one of my own identity threads — a passage from my eulogy, a role I haven't shown up as in a while, a phase-of-life timer ("Amelia at home: 3 years left"). Not a command. Not a notification. A gentle priming so the version of me that wakes up at 5am is the one who shows up.
+
+Voice · my own eulogy, not the app's opinion
+"Discipline starts strong at the beginning of the day, week, or month, but Igor often fell off the wagon. He realized that was OK, and started his discipline again the next day. This embodied compassion and having grandmother mind."
+— from Igor's eulogy
+The two-way mirror
+past informs present · future shapes today
+← LOOKING BACK
+What's already there
+Roles week summary — 11 identity threads, time-since last shown
+Year heatmap — 52-week pattern at a glance
+Recent moments log — tagged + auto-detected
+Larry export — this-week shaped for a coaching call
+→
+The bridge
+The dimmest role last week becomes today's gentle nudge. The role I haven't shown up as in 11 days becomes the eulogy passage of the morning. Past as map, future as compass.
+
+←
+LOOKING FORWARD →
+What we still need to build
+Morning whisper — today's eulogy passage, picked from the dimmest role
+5am priming widget — "who do I want to be today?" constellation on lock screen
+Phase-of-life clock — "Amelia at home: 3y 4m left"
+Sunday review as forward-setting — not just review the past, intentions for next week
+The two dragons worth battling
+scarcity is a money problem · these are an identity problem
+From idvork.in/gap-year-igor: three dragons emerge when work goes — Scarcity, Entropy, Squander. Scarcity is a money problem; Monarch Money and Boldin tame that one. The other two are this app's job. Entropy whispers that everything tends toward disorder. Squander whispers that you'll waste the precious opportunity. The eulogy version of you only loses to one of those two.
+
+∞
+ENTROPY
+"Everything tends toward disorder."
+Work's box
+Deadlines created artificial scarcity. External obligations forced order. Parkinson's law worked for you.
+
+The app's mirror
+The whole Roles tab. Time-since-last-shown. Cadences, not streaks. Daily plan + Sunday review as humane structure (not corporate ceremony).
+
+Tamed it teaches
+Self-generated discipline beats external pressure. Build the goose, not just the eggs.
+
+·
+SQUANDER
+"You will waste this precious opportunity."
+Work's box
+Calendar screenshots. Performance reviews. Even meaningless work felt productive.
+
+The app's mirror
+Roles as evidence of investment. Artifacts — not output. "Production capacity" (the goose) shown alongside "production" (the eggs).
+
+Tamed it teaches
+Productivity is alignment with values, not metrics-of-the-week.
+
+What this framing unlocks
+12 product moves the JTBD points us toward
+01 · before-call ritual
+Memory rehearsal before the Larry call
+5 min before any scheduled Larry/therapy block, surface a card with the week's roles + any flagged moments. Not to instruct — to refresh your own memory so you arrive as a better participant.
+
+Solves: showing up cold to coaching.
+02 · larry surface
+Conversation, not export
+"Grab Context" today is a one-shot JSON. The JTBD wants dialog: Larry asks a follow-up ("tell me about the Amelia situation"), the app answers with the relevant slice. Same data, different shape.
+
+Solves: Larry can't ask follow-ups about specifics.
+03 · annual review
+The natural unit between weekly and eulogy
+The eulogy is a 50-year horizon. The weekly review handles the short loop. A yearly review answers the medium arc — "in 2026, who were you mostly? Who got quieter? Who got brighter?"
+
+Solves: the gap between 7-day and 50-year horizons.
+04 · eulogy as config
+Edit the eulogy, the app reshapes
+Roles aren't hardcoded. The eulogy at idvork.in/eulogy is the source of truth — pull it on app launch, parse roles + passages, regenerate the Roles tab. Edit your eulogy → app reshapes. Anyone could install this with their own.
+
+Solves: app's worldview drifting from your actual values.
+05 · death of streaks
+Cadences, not streaks
+"You usually do X every 8 days. You're on day 11." Cadence is a neutral observation; streak is a hostile threat. Roll out across every recurring behavior in the app — meditation, gym, date nights, weekly review.
+
+Solves: streaks weaponizing the app against the user.
+06 · photo cues
+Camera roll as ambient evidence
+Your iCloud photos already document the Amelia photo outing, the family bike ride, the date night at Adam's. With on-device classification (no cloud), surface them as ambient evidence of role-appearance — no manual tagging needed.
+
+Solves: family/kids roles auto-detect almost nothing today.
+07 · "show up today"
+Elevate the verb
+The Roles design coined a concept without naming it: showing up as a role. Promote this to a first-class surface — a daily "who do you want to show up as today?" picker that pre-loads suggestions from the dimmest roles. Two taps, no notification.
+
+Solves: the move from passive observation to gentle intention.
+08 · time-since-everything
+Extend "last shown" to anything that matters
+The pattern generalizes. Last time you called Mom. Last time you finished a book. Last 8+ hour sleep. Last walk in the arboretum. Build a generic time-since registry users can populate with anything — a private layer of "this matters; how long has it been?"
+
+Solves: the long tail of "things I care about but forget to do".
+09 · ambient, not notification
+The home-screen widget is the canonical surface
+"Capture implicitly" means the app should not pester. So the canonical glance is a widget: the constellation on your lock screen with one role glowing each day. No notification. No badge. You see it because it's there, not because it interrupted you.
+
+Solves: opt-in attention vs interrupted attention.
+10 · portable identity
+If you change therapists, your context comes with you
+The export format becomes a portable identity document. Year-end, role-shaped, eulogy-grounded. A new coach onboards in 10 minutes, not 6 sessions. You're never starting over.
+
+Solves: the cold-start cost of changing coaches.
+11 · sunday ritual
+The 5am review as a guided 15-min flow
+Already in the design as a card. Promote to a real ritual: 11 short cards, one per role, prompted in eulogy voice. End with 3 intentions for the week. Save the artifact. Surface it on Today all week.
+
+Solves: weekly review is "off the wagon" 8 days in 10.
+12 · many larrys
+One context, N consumers
+Context exports feed: AI coach, human therapist, journal LLM, future-you. Each may want different slices. Design the export as a structured document with named sections, not one blob. Larry sees roles. Therapist sees mood + journal. Future-you sees the year arc.
+
+Solves: the export is currently one-size-fits-everyone.
+Five things this locks in
+design rules that fall out of the JTBD
+1 · Coach-readability of the export is a P0 feature
+The JSON must read like a one-page status memo any thoughtful human could give advice on cold. Raw HealthKit rows are evidence — not the headline. Roles section leads.
+
+2 · Glance time is the latency that matters
+Today and Roles must answer "who am I being right now?" in under 5 seconds of looking. The constellation is doing this work. Cold start matters less than visual hierarchy.
+
+3 · The app must never make you feel behind
+Time-since beats streaks. Suggestions beat commands. The moment the app makes you feel behind, the JTBD breaks — you stop opening it. No red badges. Ever.
+
+4 · Capture must stay implicit
+Anything that requires Igor to log data daily fails the JTBD on month 4. HealthKit auto. Location auto. Journal whenever you feel like it. Manual tagging optional flavor — never required.
+
+5 · Sync must be ambient by v1
+The DB must live wherever you happen to be 5 min before a Larry call. CloudKit sync for intentions + manual moments + mood is not v2 — it's v1. Otherwise the JTBD breaks across devices.
+
+What this app is NOT for
+Naming the anti-jobs explicitly so we don't drift
+NOT a fitness tracker
+Apple Health is that
+NOT a habit tracker
+Streaks would break it
+NOT a journal app
+Day One is that
+NOT a self-improvement coach
+Larry is that — we feed Larry
+NOT a QS dashboard
+Numbers are evidence, not the product
+PROPOSED NORTH-STAR METRIC
+"Did the mirror show me something true I'd have missed?"
+Tracked weekly after Sunday review or Larry call — one tap: yes / no / partially. Hit rate goes up when the mirror is faithful and humane; goes down when the app becomes noise.
+
+Engagement and DAU are not the goal — a humane mirror gets opened less than a habit tracker. The tamer the dragons, the less the app needs to roar.
+
+Today (vibes)
+~40%
+Larry hits a true note 2 of 5 calls
+Eulogy-true goal
+≥ 80%
+4 of 5 calls land
+Anti-metric
+DAU
+Optimizing this would break the JTBD
+Anti-metric
+Streaks
+See "what this is not for"
+Spec · 2026-05-25 tabbed app   ·   Plan · 2026-05-25 tabbed app plan


### PR DESCRIPTION
## Summary

Adds `docs/jtbd.md` — Igor's product-vision one-pager. Sits above the per-feature specs in `docs/superpowers/specs/` as the worldview those specs derive from.

- Verbatim print-poster text (every em-dash, column marker, "← LOOKING BACK" header preserved as written)
- 4-line YAML frontmatter: date, version (2.2), source URLs, status
- Living doc — future versions overwrite in place; git log preserves history

Derived from idvork.in/eulogy + idvork.in/gap-year-igor.

## What's in it

- Primary job ("hold up the mirror")
- The two-way mirror — looking back (mirror) + looking forward (whisper)
- The two dragons: Entropy and Squander (Scarcity is a money problem, not this app's)
- 12 product moves the JTBD points us toward
- 5 design rules that fall out of the JTBD
- 5 anti-jobs ("what this app is NOT for")
- Proposed north-star metric: "Did the mirror show me something true I'd have missed?"

## Test plan

- [ ] Render `docs/jtbd.md` on GitHub — frontmatter renders, body readable
- [ ] No accidental edits to `docs/user-needs.md` (older user-needs doc kept as-is)
- [ ] File appears in tree at `docs/jtbd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive living vision document outlining product strategy, key features, design constraints, and success metrics to guide development and align stakeholder understanding of the product's direction and scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/context-grabber/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->