### PR TITLE
fix: hoist PlacesDailyBreakdown timeline to Places tab (#40)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1846,6 +1846,10 @@ export default function App() {
         <PlacesScreen
           snapshot={snapshot}
           knownPlaces={knownPlaces}
+          db={db}
+          locationHistory={snapshot?.locationHistory ?? []}
+          setKnownPlaces={setKnownPlaces}
+          setError={setError}
           onOpenLocationDetail={() => setLocationExpanded(true)}
           onOpenSettings={() => setSettingsVisible(true)}
         />

--- a/components/LocationDetailSheet.tsx
+++ b/components/LocationDetailSheet.tsx
@@ -14,21 +14,20 @@ import * as FileSystem from "expo-file-system/legacy";
 import * as Sharing from "expo-sharing";
 import * as Clipboard from "expo-clipboard";
 import type { SQLiteDatabase } from "expo-sqlite";
-import { type KnownPlace, mergePlaceCircle } from "../lib/places";
+import { type KnownPlace } from "../lib/places";
 import {
   DB_NAME,
   getKnownPlaces,
   addKnownPlace,
   deleteKnownPlace,
-  updateKnownPlace,
   type LocationHistoryItem,
 } from "../lib/db";
 import { clusterLocations, clusterLocationsV2 } from "../lib/clustering_v2";
 import { buildPlacesDailySummary, formatPlacesDailyText } from "../lib/places_summary";
-import { haversineDistance } from "../lib/geo";
-import PlacesDailyBreakdown, { type NamePlaceTarget } from "./PlacesDailyBreakdown";
 
-const MERGE_SUGGEST_DISTANCE = 500; // meters — see places-breakdown spec section 4
+// NOTE: The per-day places timeline (PlacesDailyBreakdown) and the
+// "name this place" flow it triggers were hoisted to PlacesScreen so the
+// Places tab itself surfaces the timeline. See issue #40.
 
 type LocationData = {
   latitude: number;
@@ -76,30 +75,7 @@ export default function LocationDetailSheet({
   >("idle");
   const [dailySummaryCopied, setDailySummaryCopied] = useState(false);
 
-  // "Name this place" modal state
-  type NameModalState =
-    | { kind: "closed" }
-    | {
-        kind: "name";
-        centroid: { latitude: number; longitude: number };
-        defaultName: string;
-        sourcePlaceId: string;
-      }
-    | {
-        kind: "merge";
-        centroid: { latitude: number; longitude: number };
-        sourcePlaceId: string;
-        nearest: KnownPlace;
-        otherCount: number;
-        distance: number;
-        preview: { latitude: number; longitude: number; radiusMeters: number };
-        shift: number;
-      };
-  const [nameModal, setNameModal] = useState<NameModalState>({ kind: "closed" });
-  const [nameInput, setNameInput] = useState("");
-  const [nameRadiusInput, setNameRadiusInput] = useState("100");
-
-  // Memoize the raw points array (used by both clustering and the daily summary).
+  // Memoize the raw points array (used by clustering for both copy actions).
   const rawPoints = useMemo(
     () =>
       locationHistory.map((h) => ({
@@ -110,13 +86,6 @@ export default function LocationDetailSheet({
       })),
     [locationHistory],
   );
-
-  // Compute per-day places breakdown from location history
-  const placesDailySummary = useMemo(() => {
-    if (rawPoints.length === 0) return [];
-    const result = clusterLocationsV2(rawPoints, knownPlaces);
-    return buildPlacesDailySummary(result.stays, result.transit, rawPoints, 7);
-  }, [rawPoints, knownPlaces]);
 
   // --- Handlers ---
 
@@ -217,135 +186,23 @@ export default function LocationDetailSheet({
     }
   }
 
-  // Tap on the [+] button next to a Place N row in PlacesDailyBreakdown.
-  // Inspect proximity to known places and open either the merge-preview or
-  // name-input modal.
-  function handleNamePlaceTap(target: NamePlaceTarget) {
-    const day = placesDailySummary.find((d) => d.dateKey === target.dateKey);
-    if (!day) return;
-    const visit = day.visits[target.visitIndex];
-    if (!visit) return;
-
-    // The PlaceDaySummary doesn't carry the centroid (only stay times). Re-derive
-    // the centroid by re-running clustering on rawPoints — cheap, deterministic,
-    // and avoids leaking centroid through the summary type.
-    const cluster = clusterLocationsV2(rawPoints, knownPlaces);
-    const stay = cluster.stays.find(
-      (s) =>
-        s.placeId === visit.placeId &&
-        s.startTime <= visit.startTime &&
-        s.endTime >= visit.endTime,
-    );
-    if (!stay) return;
-    const centroid = stay.centroid;
-
-    // Find known places within MERGE_SUGGEST_DISTANCE
-    const candidates = knownPlaces
-      .map((kp) => ({
-        place: kp,
-        distance: haversineDistance(centroid.latitude, centroid.longitude, kp.latitude, kp.longitude),
-      }))
-      .filter((c) => c.distance <= MERGE_SUGGEST_DISTANCE)
-      .sort((a, b) => a.distance - b.distance);
-
-    if (candidates.length === 0) {
-      setNameInput("");
-      setNameRadiusInput("100");
-      setNameModal({
-        kind: "name",
-        centroid,
-        defaultName: "",
-        sourcePlaceId: target.placeId,
-      });
-      return;
-    }
-
-    // Branch B: merge preview
-    const nearest = candidates[0];
-    const preview = mergePlaceCircle(
-      {
-        latitude: nearest.place.latitude,
-        longitude: nearest.place.longitude,
-        radiusMeters: nearest.place.radiusMeters,
-      },
-      centroid,
-    );
-    const shift = haversineDistance(
-      nearest.place.latitude,
-      nearest.place.longitude,
-      preview.latitude,
-      preview.longitude,
-    );
-    setNameModal({
-      kind: "merge",
-      centroid,
-      sourcePlaceId: target.placeId,
-      nearest: nearest.place,
-      otherCount: candidates.length - 1,
-      distance: nearest.distance,
-      preview,
-      shift,
-    });
-  }
-
-  async function handleConfirmName() {
-    if (nameModal.kind !== "name") return;
-    if (!db) {
-      setError("Database not available. Please restart the app.");
-      return;
-    }
-    const name = nameInput.trim();
-    const radius = parseFloat(nameRadiusInput) || 100;
-    if (!name) {
-      setError("Place name is required");
-      return;
-    }
-    try {
-      await addKnownPlace(db, name, nameModal.centroid.latitude, nameModal.centroid.longitude, radius);
-      const places = await getKnownPlaces(db);
-      setKnownPlaces(places);
-      setNameModal({ kind: "closed" });
-    } catch (e: any) {
-      setError(e.message ?? "Failed to add place");
-    }
-  }
-
-  async function handleConfirmMerge() {
-    if (nameModal.kind !== "merge") return;
-    if (!db) {
-      setError("Database not available. Please restart the app.");
-      return;
-    }
-    try {
-      await updateKnownPlace(db, nameModal.nearest.id, {
-        latitude: nameModal.preview.latitude,
-        longitude: nameModal.preview.longitude,
-        radiusMeters: nameModal.preview.radiusMeters,
-      });
-      const places = await getKnownPlaces(db);
-      setKnownPlaces(places);
-      setNameModal({ kind: "closed" });
-    } catch (e: any) {
-      setError(e.message ?? "Failed to expand place");
-    }
-  }
-
-  // From the merge modal, switch to the "create new place" path.
-  function handleSwitchToCreateNew() {
-    if (nameModal.kind !== "merge") return;
-    setNameInput("");
-    setNameRadiusInput("100");
-    setNameModal({
-      kind: "name",
-      centroid: nameModal.centroid,
-      defaultName: "",
-      sourcePlaceId: nameModal.sourcePlaceId,
-    });
-  }
-
   async function handleCopyDailySummary() {
-    // Human-readable per-day per-place breakdown — same data the on-screen
-    // PlacesDailyBreakdown renders, formatted as one line per day for a life coach.
+    // Human-readable per-day per-place breakdown — same data the PlacesScreen
+    // timeline renders, formatted as one line per day for a life coach.
+    // Computed on-demand (button press) since this surface no longer renders
+    // the timeline itself.
+    const placesDailySummary =
+      rawPoints.length === 0
+        ? []
+        : (() => {
+            const result = clusterLocationsV2(rawPoints, knownPlaces);
+            return buildPlacesDailySummary(
+              result.stays,
+              result.transit,
+              rawPoints,
+              7,
+            );
+          })();
     const text = formatPlacesDailyText(placesDailySummary);
     await Clipboard.setStringAsync(text);
     setDailySummaryCopied(true);
@@ -504,10 +361,6 @@ export default function LocationDetailSheet({
             )}
           </View>
 
-          {placesDailySummary.length > 0 && (
-            <PlacesDailyBreakdown days={placesDailySummary} onNamePlace={handleNamePlaceTap} />
-          )}
-
           <View style={styles.aboutCard}>
             <TouchableOpacity
               style={[styles.addPlaceButton, { marginTop: 12 }]}
@@ -646,98 +499,6 @@ export default function LocationDetailSheet({
         </ScrollView>
       </View>
 
-      {/* Name / Merge place modal */}
-      <Modal
-        visible={nameModal.kind !== "closed"}
-        animationType="fade"
-        transparent
-        onRequestClose={() => setNameModal({ kind: "closed" })}
-      >
-        <View style={styles.namePlaceBackdrop}>
-          <View style={styles.namePlaceCard}>
-            {nameModal.kind === "name" && (
-              <>
-                <Text style={styles.namePlaceTitle}>Name this place</Text>
-                <Text style={styles.namePlaceCoords}>
-                  {nameModal.centroid.latitude.toFixed(5)}, {nameModal.centroid.longitude.toFixed(5)}
-                </Text>
-                <TextInput
-                  style={styles.addPlaceInput}
-                  placeholder="Place name"
-                  placeholderTextColor="#666"
-                  value={nameInput}
-                  onChangeText={setNameInput}
-                  autoFocus
-                  testID="name-place-input"
-                />
-                <TextInput
-                  style={[styles.addPlaceInput, { marginTop: 8 }]}
-                  placeholder="Radius (m)"
-                  placeholderTextColor="#666"
-                  value={nameRadiusInput}
-                  onChangeText={setNameRadiusInput}
-                  keyboardType="number-pad"
-                />
-                <View style={styles.namePlaceButtonRow}>
-                  <TouchableOpacity
-                    style={[styles.addPlaceButton, styles.namePlaceCancelButton]}
-                    onPress={() => setNameModal({ kind: "closed" })}
-                  >
-                    <Text style={styles.addPlaceButtonText}>Cancel</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.addPlaceButton, { flex: 1 }]}
-                    onPress={handleConfirmName}
-                    testID="name-place-save"
-                  >
-                    <Text style={styles.addPlaceButtonText}>Save</Text>
-                  </TouchableOpacity>
-                </View>
-              </>
-            )}
-
-            {nameModal.kind === "merge" && (
-              <>
-                <Text style={styles.namePlaceTitle}>Nearby known place</Text>
-                <Text style={styles.namePlaceBody}>
-                  <Text style={{ fontWeight: "700" }}>{nameModal.sourcePlaceId}</Text> is{" "}
-                  {Math.round(nameModal.distance)}m from{" "}
-                  <Text style={{ fontWeight: "700" }}>{nameModal.nearest.name}</Text>.
-                </Text>
-                <Text style={styles.namePlaceBody}>
-                  Expanding would grow radius {Math.round(nameModal.nearest.radiusMeters)}m →{" "}
-                  {Math.round(nameModal.preview.radiusMeters)}m and shift the center by{" "}
-                  {Math.round(nameModal.shift)}m.
-                </Text>
-                {nameModal.otherCount > 0 && (
-                  <Text style={styles.namePlaceHint}>(+{nameModal.otherCount} more within 500m)</Text>
-                )}
-                <View style={styles.namePlaceButtonRow}>
-                  <TouchableOpacity
-                    style={[styles.addPlaceButton, styles.namePlaceCancelButton]}
-                    onPress={() => setNameModal({ kind: "closed" })}
-                  >
-                    <Text style={styles.addPlaceButtonText}>Cancel</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.addPlaceButton, { backgroundColor: "#3d405b", flex: 1 }]}
-                    onPress={handleSwitchToCreateNew}
-                  >
-                    <Text style={styles.addPlaceButtonText}>Create new</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.addPlaceButton, { flex: 1 }]}
-                    onPress={handleConfirmMerge}
-                    testID="merge-place-confirm"
-                  >
-                    <Text style={styles.addPlaceButtonText}>Expand {nameModal.nearest.name}</Text>
-                  </TouchableOpacity>
-                </View>
-              </>
-            )}
-          </View>
-        </View>
-      </Modal>
     </Modal>
   );
 }
@@ -874,49 +635,6 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 14,
     fontWeight: "600",
-  },
-  namePlaceBackdrop: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.6)",
-    justifyContent: "center",
-    paddingHorizontal: 24,
-  },
-  namePlaceCard: {
-    backgroundColor: "#16213e",
-    borderRadius: 14,
-    padding: 20,
-  },
-  namePlaceTitle: {
-    color: "#e0e0e0",
-    fontSize: 18,
-    fontWeight: "700",
-    marginBottom: 8,
-  },
-  namePlaceCoords: {
-    color: "#888",
-    fontSize: 12,
-    fontFamily: "Courier",
-    marginBottom: 12,
-  },
-  namePlaceBody: {
-    color: "#ccc",
-    fontSize: 14,
-    marginBottom: 8,
-    lineHeight: 20,
-  },
-  namePlaceHint: {
-    color: "#888",
-    fontSize: 12,
-    marginBottom: 4,
-  },
-  namePlaceButtonRow: {
-    flexDirection: "row",
-    gap: 8,
-    marginTop: 12,
-  },
-  namePlaceCancelButton: {
-    backgroundColor: "#3d1f1f",
-    flex: 0.7,
   },
   coordsRow: {
     flexDirection: "row",

--- a/screens/PlacesScreen.tsx
+++ b/screens/PlacesScreen.tsx
@@ -1,28 +1,241 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import {
+  Modal,
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
+import type { SQLiteDatabase } from "expo-sqlite";
 import { StylizedMap } from "../components/StylizedMap";
+import PlacesDailyBreakdown, {
+  type NamePlaceTarget,
+} from "../components/PlacesDailyBreakdown";
 import type { ContextSnapshot } from "../lib/appTypes";
-import type { KnownPlace } from "../lib/places";
+import {
+  type KnownPlace,
+  mergePlaceCircle,
+} from "../lib/places";
+import {
+  addKnownPlace,
+  getKnownPlaces,
+  updateKnownPlace,
+  type LocationHistoryItem,
+} from "../lib/db";
+import { clusterLocationsV2 } from "../lib/clustering_v2";
+import { buildPlacesDailySummary } from "../lib/places_summary";
+import { haversineDistance } from "../lib/geo";
+
+const MERGE_SUGGEST_DISTANCE = 500; // meters — see places-breakdown spec section 4
 
 type Props = {
   snapshot: ContextSnapshot | null;
   knownPlaces: KnownPlace[];
+  db: SQLiteDatabase | null;
+  locationHistory: LocationHistoryItem[];
+  setKnownPlaces: (places: KnownPlace[]) => void;
+  setError: (msg: string | null) => void;
   onOpenLocationDetail: () => void;
   onOpenSettings: () => void;
 };
 
+// "Name this place" modal state (lifted from LocationDetailSheet)
+type NameModalState =
+  | { kind: "closed" }
+  | {
+      kind: "name";
+      centroid: { latitude: number; longitude: number };
+      defaultName: string;
+      sourcePlaceId: string;
+    }
+  | {
+      kind: "merge";
+      centroid: { latitude: number; longitude: number };
+      sourcePlaceId: string;
+      nearest: KnownPlace;
+      otherCount: number;
+      distance: number;
+      preview: { latitude: number; longitude: number; radiusMeters: number };
+      shift: number;
+    };
+
 export function PlacesScreen({
   snapshot,
   knownPlaces,
+  db,
+  locationHistory,
+  setKnownPlaces,
+  setError,
   onOpenLocationDetail,
   onOpenSettings,
 }: Props) {
+  // Name/merge modal state — hoisted from LocationDetailSheet so the [+ name
+  // this place] button on the tab-level timeline works without opening the
+  // sheet.
+  const [nameModal, setNameModal] = useState<NameModalState>({ kind: "closed" });
+  const [nameInput, setNameInput] = useState("");
+  const [nameRadiusInput, setNameRadiusInput] = useState("100");
+
+  // Raw points for clustering (used by both the daily breakdown and the
+  // naming flow's centroid lookup).
+  const rawPoints = useMemo(
+    () =>
+      locationHistory.map((h) => ({
+        latitude: h.latitude,
+        longitude: h.longitude,
+        timestamp: h.timestamp,
+        accuracy: h.accuracy ?? 0,
+      })),
+    [locationHistory],
+  );
+
+  // Per-day places breakdown — the timeline the Places tab is supposed to
+  // surface per spec (2026-05-25-tabbed-app-design.md acceptance criterion
+  // "Today + Yesterday timeline shows all clusters with start/end times").
+  const placesDailySummary = useMemo(() => {
+    if (rawPoints.length === 0) return [];
+    const result = clusterLocationsV2(rawPoints, knownPlaces);
+    return buildPlacesDailySummary(result.stays, result.transit, rawPoints, 7);
+  }, [rawPoints, knownPlaces]);
+
+  // Tap on the [+] button next to a "Place N" row in PlacesDailyBreakdown.
+  // Inspect proximity to known places and open either the merge-preview or
+  // name-input modal.
+  function handleNamePlaceTap(target: NamePlaceTarget) {
+    const day = placesDailySummary.find((d) => d.dateKey === target.dateKey);
+    if (!day) return;
+    const visit = day.visits[target.visitIndex];
+    if (!visit) return;
+
+    // PlaceDaySummary doesn't carry the centroid (only stay times). Re-derive
+    // by re-running clustering on rawPoints — cheap, deterministic, and avoids
+    // leaking centroid through the summary type.
+    const cluster = clusterLocationsV2(rawPoints, knownPlaces);
+    const stay = cluster.stays.find(
+      (s) =>
+        s.placeId === visit.placeId &&
+        s.startTime <= visit.startTime &&
+        s.endTime >= visit.endTime,
+    );
+    if (!stay) return;
+    const centroid = stay.centroid;
+
+    // Find known places within MERGE_SUGGEST_DISTANCE.
+    const candidates = knownPlaces
+      .map((kp) => ({
+        place: kp,
+        distance: haversineDistance(
+          centroid.latitude,
+          centroid.longitude,
+          kp.latitude,
+          kp.longitude,
+        ),
+      }))
+      .filter((c) => c.distance <= MERGE_SUGGEST_DISTANCE)
+      .sort((a, b) => a.distance - b.distance);
+
+    if (candidates.length === 0) {
+      setNameInput("");
+      setNameRadiusInput("100");
+      setNameModal({
+        kind: "name",
+        centroid,
+        defaultName: "",
+        sourcePlaceId: target.placeId,
+      });
+      return;
+    }
+
+    const nearest = candidates[0];
+    const preview = mergePlaceCircle(
+      {
+        latitude: nearest.place.latitude,
+        longitude: nearest.place.longitude,
+        radiusMeters: nearest.place.radiusMeters,
+      },
+      centroid,
+    );
+    const shift = haversineDistance(
+      nearest.place.latitude,
+      nearest.place.longitude,
+      preview.latitude,
+      preview.longitude,
+    );
+    setNameModal({
+      kind: "merge",
+      centroid,
+      sourcePlaceId: target.placeId,
+      nearest: nearest.place,
+      otherCount: candidates.length - 1,
+      distance: nearest.distance,
+      preview,
+      shift,
+    });
+  }
+
+  async function handleConfirmName() {
+    if (nameModal.kind !== "name") return;
+    if (!db) {
+      setError("Database not available. Please restart the app.");
+      return;
+    }
+    const name = nameInput.trim();
+    const radius = parseFloat(nameRadiusInput) || 100;
+    if (!name) {
+      setError("Place name is required");
+      return;
+    }
+    try {
+      await addKnownPlace(
+        db,
+        name,
+        nameModal.centroid.latitude,
+        nameModal.centroid.longitude,
+        radius,
+      );
+      const places = await getKnownPlaces(db);
+      setKnownPlaces(places);
+      setNameModal({ kind: "closed" });
+    } catch (e: any) {
+      setError(e.message ?? "Failed to add place");
+    }
+  }
+
+  async function handleConfirmMerge() {
+    if (nameModal.kind !== "merge") return;
+    if (!db) {
+      setError("Database not available. Please restart the app.");
+      return;
+    }
+    try {
+      await updateKnownPlace(db, nameModal.nearest.id, {
+        latitude: nameModal.preview.latitude,
+        longitude: nameModal.preview.longitude,
+        radiusMeters: nameModal.preview.radiusMeters,
+      });
+      const places = await getKnownPlaces(db);
+      setKnownPlaces(places);
+      setNameModal({ kind: "closed" });
+    } catch (e: any) {
+      setError(e.message ?? "Failed to expand place");
+    }
+  }
+
+  // From the merge modal, switch to the "create new place" path.
+  function handleSwitchToCreateNew() {
+    if (nameModal.kind !== "merge") return;
+    setNameInput("");
+    setNameRadiusInput("100");
+    setNameModal({
+      kind: "name",
+      centroid: nameModal.centroid,
+      defaultName: "",
+      sourcePlaceId: nameModal.sourcePlaceId,
+    });
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -60,6 +273,13 @@ export function PlacesScreen({
             })()}
           </Text>
         </View>
+
+        {placesDailySummary.length > 0 && (
+          <PlacesDailyBreakdown
+            days={placesDailySummary}
+            onNamePlace={handleNamePlaceTap}
+          />
+        )}
 
         <Text style={styles.sectionHeading}>
           Known places ({knownPlaces.length})
@@ -100,6 +320,100 @@ export function PlacesScreen({
           <Text style={styles.actionBtnText}>Tracking · retention</Text>
         </TouchableOpacity>
       </ScrollView>
+
+      {/* Name / Merge place modal — lifted from LocationDetailSheet so the
+          [+ name this place] button on the tab-level timeline works. */}
+      <Modal
+        visible={nameModal.kind !== "closed"}
+        animationType="fade"
+        transparent
+        onRequestClose={() => setNameModal({ kind: "closed" })}
+      >
+        <View style={styles.namePlaceBackdrop}>
+          <View style={styles.namePlaceCard}>
+            {nameModal.kind === "name" && (
+              <>
+                <Text style={styles.namePlaceTitle}>Name this place</Text>
+                <Text style={styles.namePlaceCoords}>
+                  {nameModal.centroid.latitude.toFixed(5)}, {nameModal.centroid.longitude.toFixed(5)}
+                </Text>
+                <TextInput
+                  style={styles.namePlaceInput}
+                  placeholder="Place name"
+                  placeholderTextColor="#666"
+                  value={nameInput}
+                  onChangeText={setNameInput}
+                  autoFocus
+                  testID="name-place-input"
+                />
+                <TextInput
+                  style={[styles.namePlaceInput, { marginTop: 8 }]}
+                  placeholder="Radius (m)"
+                  placeholderTextColor="#666"
+                  value={nameRadiusInput}
+                  onChangeText={setNameRadiusInput}
+                  keyboardType="number-pad"
+                />
+                <View style={styles.namePlaceButtonRow}>
+                  <TouchableOpacity
+                    style={[styles.namePlaceButton, styles.namePlaceCancelButton]}
+                    onPress={() => setNameModal({ kind: "closed" })}
+                  >
+                    <Text style={styles.namePlaceButtonText}>Cancel</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.namePlaceButton, { flex: 1 }]}
+                    onPress={handleConfirmName}
+                    testID="name-place-save"
+                  >
+                    <Text style={styles.namePlaceButtonText}>Save</Text>
+                  </TouchableOpacity>
+                </View>
+              </>
+            )}
+
+            {nameModal.kind === "merge" && (
+              <>
+                <Text style={styles.namePlaceTitle}>Nearby known place</Text>
+                <Text style={styles.namePlaceBody}>
+                  <Text style={{ fontWeight: "700" }}>{nameModal.sourcePlaceId}</Text> is{" "}
+                  {Math.round(nameModal.distance)}m from{" "}
+                  <Text style={{ fontWeight: "700" }}>{nameModal.nearest.name}</Text>.
+                </Text>
+                <Text style={styles.namePlaceBody}>
+                  Expanding would grow radius {Math.round(nameModal.nearest.radiusMeters)}m →{" "}
+                  {Math.round(nameModal.preview.radiusMeters)}m and shift the center by{" "}
+                  {Math.round(nameModal.shift)}m.
+                </Text>
+                {nameModal.otherCount > 0 && (
+                  <Text style={styles.namePlaceHint}>(+{nameModal.otherCount} more within 500m)</Text>
+                )}
+                <View style={styles.namePlaceButtonRow}>
+                  <TouchableOpacity
+                    style={[styles.namePlaceButton, styles.namePlaceCancelButton]}
+                    onPress={() => setNameModal({ kind: "closed" })}
+                  >
+                    <Text style={styles.namePlaceButtonText}>Cancel</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.namePlaceButton, { backgroundColor: "#3d405b", flex: 1 }]}
+                    onPress={handleSwitchToCreateNew}
+                  >
+                    <Text style={styles.namePlaceButtonText}>Create new</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.namePlaceButton, { flex: 1 }]}
+                    onPress={handleConfirmMerge}
+                    testID="merge-place-confirm"
+                  >
+                    <Text style={styles.namePlaceButtonText}>Expand {nameModal.nearest.name}</Text>
+                  </TouchableOpacity>
+                </View>
+              </>
+            )}
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -172,4 +486,68 @@ const styles = StyleSheet.create({
     backgroundColor: "#3d405b",
   },
   actionBtnText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  namePlaceBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  namePlaceCard: {
+    backgroundColor: "#16213e",
+    borderRadius: 14,
+    padding: 20,
+  },
+  namePlaceTitle: {
+    color: "#e0e0e0",
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: 8,
+  },
+  namePlaceCoords: {
+    color: "#888",
+    fontSize: 12,
+    fontFamily: "Courier",
+    marginBottom: 12,
+  },
+  namePlaceBody: {
+    color: "#ccc",
+    fontSize: 14,
+    marginBottom: 8,
+    lineHeight: 20,
+  },
+  namePlaceHint: {
+    color: "#888",
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  namePlaceInput: {
+    backgroundColor: "#1a1a2e",
+    color: "#fff",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    borderWidth: 1,
+    borderColor: "#333",
+  },
+  namePlaceButtonRow: {
+    flexDirection: "row",
+    gap: 8,
+    marginTop: 12,
+  },
+  namePlaceButton: {
+    backgroundColor: "#2d6a4f",
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  namePlaceButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  namePlaceCancelButton: {
+    backgroundColor: "#3d1f1f",
+    flex: 0.7,
+  },
 });


### PR DESCRIPTION
## Summary

Fixes #40. The Places tab landed in the tabbed-shell refactor (#38) without the per-day timeline. `PlacesDailyBreakdown` still exists and works, but was buried two taps deep inside `LocationDetailSheet` — so the Places tab itself reads as a "list of Copy actions," and the spec acceptance criterion at `docs/superpowers/specs/2026-05-25-tabbed-app-design.md:241` ("Today + Yesterday timeline shows all clusters with start/end times") was unmet.

## What moved

Hoisted three pieces from `LocationDetailSheet.tsx` up to `screens/PlacesScreen.tsx`:

1. **The `placesDailySummary` compute** — `clusterLocationsV2` + `buildPlacesDailySummary` over the location history.
2. **The `<PlacesDailyBreakdown>` render** — placed below the current-location summary card so it's the second thing on the Places tab.
3. **The `handleNamePlaceTap` flow** — centroid re-derivation, known-place proximity check, and the name/merge modal it triggers (so the [+ name this place] button on `Place N` rows still works from the tab-level timeline).

## What shrank

`LocationDetailSheet.tsx` is now focused on its remaining jobs: Known Places CRUD, retention settings, Export Database, and the three Copy buttons. It no longer renders the timeline. The "Copy Daily Summary" handler still needs the per-day summary; it now computes on-demand on button press rather than via `useMemo` (single-shot, fine without memoization).

`App.tsx` threads `db`, `locationHistory`, `setKnownPlaces`, and `setError` into `PlacesScreen` so the naming flow can write back.

Net diff: `LocationDetailSheet` -296 lines, `PlacesScreen` +378 lines, `App.tsx` +4. The naming-modal markup + styles moved verbatim; no behavioral changes to the name/merge UX.

## Verification done

- `npx tsc --noEmit` — clean (no type errors)
- `npx jest` — 481/481 tests pass

## Limitation

**No iOS simulator smoke-test from this env** — I can't render the app to confirm the timeline visually anchors below the current-location card or that the [+ name this place] button still opens the name/merge modal correctly. Igor needs to validate on device:

- [ ] Open Places tab, confirm per-day timeline (Today + Yesterday + ~5 prior days) renders below "Current" card
- [ ] Tap a "Place N" row's [+] button → name/merge modal opens
- [ ] Save a new place → confirm it appears in Known Places (still inside the sheet)
- [ ] Open the "Manage places · history · export" sheet → confirm timeline no longer duplicated there, but "Copy Daily Summary" button still works

## After merge

Issue #40 ready to close.

## Test plan

- [ ] iOS device smoke-test (per Limitation above)
- [ ] CI: `npx tsc --noEmit` and `npx jest` both pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Name and merge place locations directly from the Places screen with streamlined confirmation dialogs, improving place management efficiency.

* **Improvements**
  * Daily places timeline and naming flows have been reorganized for better accessibility and improved user experience, consolidating place management tools in one dedicated view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/context-grabber/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->