### PR TITLE
feat(places-map): overlay today's path on StylizedMap (Option A of #42)

### DIFF
--- a/__tests__/StylizedMap.test.tsx
+++ b/__tests__/StylizedMap.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, act, fireEvent } from "@testing-library/react-native";
+import { StylizedMap, type PathPoint } from "../components/StylizedMap";
+
+// Fire an onLayout event so the component knows the frame's pt size; the
+// path-segment renderer skips when frameSize is null.
+function layoutMap(testID: string, getByTestId: (id: string) => any) {
+  const map = getByTestId(testID);
+  act(() => {
+    fireEvent(map, "layout", {
+      nativeEvent: { layout: { width: 320, height: 180, x: 0, y: 0 } },
+    });
+  });
+}
+
+describe("StylizedMap path overlay", () => {
+  const baseProps = {
+    currentLocation: {
+      latitude: 47.61,
+      longitude: -122.33,
+      timestamp: Date.now(),
+    },
+    knownPlaces: [
+      {
+        id: 1,
+        name: "Home",
+        latitude: 47.6419,
+        longitude: -122.3045,
+        radiusMeters: 100,
+      },
+    ],
+  };
+
+  it("renders pins without a path prop (backward compat)", () => {
+    const result = render(<StylizedMap {...baseProps} />);
+    expect(result.getByTestId("stylized-map")).toBeTruthy();
+    expect(result.getByTestId("map-pin-current")).toBeTruthy();
+    expect(result.getByTestId("map-pin-p-1")).toBeTruthy();
+    // No path → no segments and no path dots.
+    expect(result.queryByTestId("seg-1")).toBeNull();
+    expect(result.queryByTestId("map-path-dot-0")).toBeNull();
+  });
+
+  it("renders no path overlay when path has < 2 points", () => {
+    const path: PathPoint[] = [{ lat: 47.6, lon: -122.33 }];
+    const result = render(<StylizedMap {...baseProps} path={path} />);
+    layoutMap("stylized-map", result.getByTestId);
+    expect(result.queryByTestId("seg-1")).toBeNull();
+    expect(result.queryByTestId("map-path-dot-0")).toBeNull();
+  });
+
+  it("renders polyline segments + dots for a 3-point path", () => {
+    const path: PathPoint[] = [
+      { lat: 47.6419, lon: -122.3045, timestamp: 1 }, // Home
+      { lat: 47.6289, lon: -122.3432, timestamp: 2 }, // Work
+      { lat: 47.6762, lon: -122.3187, timestamp: 3 }, // KB gym
+    ];
+    const result = render(<StylizedMap {...baseProps} path={path} />);
+    layoutMap("stylized-map", result.getByTestId);
+
+    // Two segments connect three points.
+    expect(result.getByTestId("seg-1")).toBeTruthy();
+    expect(result.getByTestId("seg-2")).toBeTruthy();
+    expect(result.queryByTestId("seg-3")).toBeNull();
+
+    // One breadcrumb dot per path point.
+    expect(result.getByTestId("map-path-dot-0")).toBeTruthy();
+    expect(result.getByTestId("map-path-dot-1")).toBeTruthy();
+    expect(result.getByTestId("map-path-dot-2")).toBeTruthy();
+
+    // Pins still render on top of the path.
+    expect(result.getByTestId("map-pin-current")).toBeTruthy();
+    expect(result.getByTestId("map-pin-p-1")).toBeTruthy();
+  });
+
+  it("filters non-finite path points", () => {
+    const path: PathPoint[] = [
+      { lat: 47.6419, lon: -122.3045 },
+      { lat: NaN, lon: -122.32 },
+      { lat: 47.6289, lon: -122.3432 },
+    ];
+    const result = render(<StylizedMap {...baseProps} path={path} />);
+    layoutMap("stylized-map", result.getByTestId);
+
+    // After filtering, only 2 valid points → 1 segment, 2 dots.
+    expect(result.getByTestId("seg-1")).toBeTruthy();
+    expect(result.queryByTestId("seg-2")).toBeNull();
+    expect(result.getByTestId("map-path-dot-0")).toBeTruthy();
+    expect(result.getByTestId("map-path-dot-1")).toBeTruthy();
+    expect(result.queryByTestId("map-path-dot-2")).toBeNull();
+  });
+
+  it("renders empty state when there are no pins and no path", () => {
+    const result = render(
+      <StylizedMap currentLocation={null} knownPlaces={[]} />,
+    );
+    expect(result.getByTestId("stylized-map")).toBeTruthy();
+    // Empty hint text from existing behavior.
+    expect(
+      result.getByText(
+        /No location yet — grab context or add a known place\./,
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/components/StylizedMap.tsx
+++ b/components/StylizedMap.tsx
@@ -1,7 +1,16 @@
-import React, { useMemo } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import React, { useMemo, useState } from "react";
+import { LayoutChangeEvent, StyleSheet, Text, View } from "react-native";
 import type { KnownPlace } from "../lib/places";
 import type { LocationData } from "../lib/appTypes";
+
+/** A point on the day's path overlay. `timestamp` is optional and unused for
+ * rendering today — it exists so callers can pass `Stay`-shaped data without
+ * stripping fields. */
+export type PathPoint = {
+  lat: number;
+  lon: number;
+  timestamp?: number;
+};
 
 type Props = {
   /** Current GPS location, if available. */
@@ -10,6 +19,14 @@ type Props = {
   knownPlaces: KnownPlace[];
   /** Map height in pt. Default 180. */
   height?: number;
+  /**
+   * Optional ordered breadcrumbs for today's path. Rendered as a polyline
+   * overlay connecting the points in array order (so callers should sort
+   * by time first). When 2+ points are present, also extends the projection
+   * bounding box so the path stays inside the frame. Empty / single-point
+   * arrays render nothing extra.
+   */
+  path?: PathPoint[];
 };
 
 /**
@@ -23,7 +40,18 @@ type Props = {
  * with 10% padding. Pins inside the same square render at consistent
  * relative positions across grabs.
  */
-export function StylizedMap({ currentLocation, knownPlaces, height = 180 }: Props) {
+export function StylizedMap({
+  currentLocation,
+  knownPlaces,
+  height = 180,
+  path,
+}: Props) {
+  // Frame size — needed to compute segment lengths in pt for the path
+  // polyline overlay (we can't rotate a percentage-width line accurately
+  // because rotation needs a known length). Default to a sensible value;
+  // onLayout updates it once the frame measures.
+  const [frameSize, setFrameSize] = useState<{ width: number; height: number } | null>(null);
+
   const projected = useMemo(() => {
     const pts: Array<{ lat: number; lng: number; kind: "current" | "place"; label: string; id: string }> = [];
     for (const p of knownPlaces) {
@@ -44,16 +72,32 @@ export function StylizedMap({ currentLocation, knownPlaces, height = 180 }: Prop
         id: "current",
       });
     }
-    if (pts.length === 0) return null;
 
-    if (pts.length === 1) {
+    // Path points participate in the bounding box so the polyline can't
+    // wander off-frame, but they're not rendered as labelled pins.
+    const pathPts = (path ?? []).filter(
+      (p) => Number.isFinite(p.lat) && Number.isFinite(p.lon),
+    );
+
+    if (pts.length === 0 && pathPts.length === 0) return null;
+
+    if (pts.length + pathPts.length === 1) {
+      // Only one point of any kind — center it.
+      const onlyPath = pts.length === 0;
       return {
         points: pts.map((p) => ({ ...p, x: 0.5, y: 0.5 })),
+        path: onlyPath ? [{ x: 0.5, y: 0.5 }] : [],
       };
     }
 
-    const lats = pts.map((p) => p.lat);
-    const lngs = pts.map((p) => p.lng);
+    const lats = [
+      ...pts.map((p) => p.lat),
+      ...pathPts.map((p) => p.lat),
+    ];
+    const lngs = [
+      ...pts.map((p) => p.lng),
+      ...pathPts.map((p) => p.lon),
+    ];
     const minLat = Math.min(...lats);
     const maxLat = Math.max(...lats);
     const minLng = Math.min(...lngs);
@@ -65,18 +109,75 @@ export function StylizedMap({ currentLocation, knownPlaces, height = 180 }: Prop
 
     // 10% padding so pins aren't flush against the edges.
     const pad = 0.1;
+    const project = (lat: number, lng: number) => ({
+      x: pad + ((lng - minLng) / lngRange) * (1 - 2 * pad),
+      // y is inverted: higher lat = top of screen.
+      y: pad + (1 - (lat - minLat) / latRange) * (1 - 2 * pad),
+    });
+
     return {
-      points: pts.map((p) => ({
-        ...p,
-        x: pad + ((p.lng - minLng) / lngRange) * (1 - 2 * pad),
-        // y is inverted: higher lat = top of screen.
-        y: pad + (1 - (p.lat - minLat) / latRange) * (1 - 2 * pad),
-      })),
+      points: pts.map((p) => ({ ...p, ...project(p.lat, p.lng) })),
+      path: pathPts.map((p) => project(p.lat, p.lon)),
     };
-  }, [currentLocation, knownPlaces]);
+  }, [currentLocation, knownPlaces, path]);
+
+  // Polyline segments between consecutive path points. Computed in pt
+  // (not %) because rotation requires a real length.
+  const pathSegments = useMemo(() => {
+    if (!projected || !frameSize) return [];
+    if (projected.path.length < 2) return [];
+    const w = frameSize.width;
+    const h = frameSize.height;
+    const segs: Array<{
+      key: string;
+      left: number;
+      top: number;
+      width: number;
+      angle: number;
+    }> = [];
+    for (let i = 1; i < projected.path.length; i++) {
+      const a = projected.path[i - 1];
+      const b = projected.path[i];
+      const ax = a.x * w;
+      const ay = a.y * h;
+      const bx = b.x * w;
+      const by = b.y * h;
+      const dx = bx - ax;
+      const dy = by - ay;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len < 0.5) continue;
+      const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
+      // Offset top by half the segment height so the line is vertically
+      // centered on (ax, ay) — the transformOrigin pivot ("left center")
+      // expects the rotation point to be at the vertical middle.
+      segs.push({
+        key: `seg-${i}`,
+        left: ax,
+        top: ay - 1,
+        width: len,
+        angle,
+      });
+    }
+    return segs;
+  }, [projected, frameSize]);
+
+  function handleLayout(e: LayoutChangeEvent) {
+    const { width, height: h } = e.nativeEvent.layout;
+    if (
+      !frameSize ||
+      Math.abs(frameSize.width - width) > 0.5 ||
+      Math.abs(frameSize.height - h) > 0.5
+    ) {
+      setFrameSize({ width, height: h });
+    }
+  }
 
   return (
-    <View style={[styles.frame, { height }]} testID="stylized-map">
+    <View
+      style={[styles.frame, { height }]}
+      testID="stylized-map"
+      onLayout={handleLayout}
+    >
       <View style={styles.backdrop} />
       <View style={styles.gridH1} />
       <View style={styles.gridH2} />
@@ -89,6 +190,42 @@ export function StylizedMap({ currentLocation, knownPlaces, height = 180 }: Prop
           </Text>
         </View>
       )}
+      {/* Path polyline — render BEFORE pins so pins sit on top. Each segment
+          is a 1px-tall view rotated to align with its endpoints. */}
+      {pathSegments.map((s) => (
+        <View
+          key={s.key}
+          testID={s.key}
+          pointerEvents="none"
+          style={[
+            styles.pathSegment,
+            {
+              left: s.left,
+              top: s.top,
+              width: s.width,
+              transform: [{ rotate: `${s.angle}deg` }],
+            },
+          ]}
+        />
+      ))}
+      {/* Small dots at each path breadcrumb. Skipped when there's only one
+          point or when the frame hasn't measured yet. */}
+      {frameSize && projected && projected.path.length >= 2
+        ? projected.path.map((p, idx) => (
+            <View
+              key={`path-dot-${idx}`}
+              testID={`map-path-dot-${idx}`}
+              pointerEvents="none"
+              style={[
+                styles.pathDot,
+                {
+                  left: `${p.x * 100}%`,
+                  top: `${p.y * 100}%`,
+                },
+              ]}
+            />
+          ))
+        : null}
       {projected?.points.map((p) => (
         <View
           key={p.id}
@@ -151,5 +288,25 @@ const styles = StyleSheet.create({
     left: -10,
     top: -10,
     backgroundColor: "rgba(76, 201, 240, 0.18)",
+  },
+  pathSegment: {
+    position: "absolute",
+    height: 2,
+    backgroundColor: "rgba(76, 201, 240, 0.55)",
+    // Default RN rotation pivots around the view's center; we want the
+    // rotation to pivot around the start point (left edge, vertical center)
+    // so the segment extends toward the next breadcrumb.
+    transformOrigin: "left center",
+    borderRadius: 1,
+  },
+  pathDot: {
+    position: "absolute",
+    width: 5,
+    height: 5,
+    borderRadius: 2.5,
+    marginLeft: -2.5,
+    marginTop: -2.5,
+    backgroundColor: "#4cc9f0",
+    opacity: 0.85,
   },
 });

--- a/docs/superpowers/specs/2026-05-25-tabbed-app-design.md
+++ b/docs/superpowers/specs/2026-05-25-tabbed-app-design.md
@@ -67,6 +67,8 @@ Journal (text + voice), Affirmation, Gratitude, Tally Counter, **meditation flat
 
 Map + today/yesterday timeline + Known Places CRUD + background tracking toggle + retention stepper + Export DB. Map is a stylized SVG in v1 — no Apple Maps key, no react-native-maps. Same data as today, organized as a real screen instead of a modal.
 
+The map also surfaces **today's path** as a polyline overlay: today's visited places connected in chronological order by a thin tinted line, with a small dot at each breadcrumb. Known-place pins and the current-location pin stay rendered on top. When today's path has 0–1 stays, the map renders exactly as before (pins only) — the overlay is purely additive.
+
 ### Roles
 
 The new tab. See its own section below.
@@ -242,6 +244,8 @@ A QA-style checklist; testable without seeing the code.
 - [ ] Known Places CRUD works exactly as the existing LocationDetailSheet
 - [ ] Background tracking toggle, retention stepper, Export DB present and functional
 - [ ] Map renders as a stylized SVG (no Apple Maps); pins anchor to known places
+- [ ] When today has 2+ stays, the map overlays a path polyline (line + dots) connecting them in time order; the current-location and known-place pins still render on top
+- [ ] When today has 0 or 1 stays, no path overlay is drawn (map renders as it did before this feature)
 
 ### Roles
 

--- a/screens/PlacesScreen.tsx
+++ b/screens/PlacesScreen.tsx
@@ -91,14 +91,45 @@ export function PlacesScreen({
     [locationHistory],
   );
 
+  // Cluster output reused twice — once for the daily breakdown table, once
+  // for today's path overlay on the map. Memoize to avoid recomputing.
+  const clusterResult = useMemo(() => {
+    if (rawPoints.length === 0) return null;
+    return clusterLocationsV2(rawPoints, knownPlaces);
+  }, [rawPoints, knownPlaces]);
+
   // Per-day places breakdown — the timeline the Places tab is supposed to
   // surface per spec (2026-05-25-tabbed-app-design.md acceptance criterion
   // "Today + Yesterday timeline shows all clusters with start/end times").
   const placesDailySummary = useMemo(() => {
-    if (rawPoints.length === 0) return [];
-    const result = clusterLocationsV2(rawPoints, knownPlaces);
-    return buildPlacesDailySummary(result.stays, result.transit, rawPoints, 7);
-  }, [rawPoints, knownPlaces]);
+    if (!clusterResult) return [];
+    return buildPlacesDailySummary(
+      clusterResult.stays,
+      clusterResult.transit,
+      rawPoints,
+      7,
+    );
+  }, [clusterResult, rawPoints]);
+
+  // Today's path overlay — stay centroids in chronological order, filtered
+  // to stays that overlap today's local-time window. Used by StylizedMap to
+  // draw a polyline between the day's visited known places. Per issue #42
+  // Option A: "Overlay today's location path (breadcrumbs / route)".
+  const todaysPath = useMemo(() => {
+    if (!clusterResult) return [];
+    const now = Date.now();
+    const dayStart = new Date(now);
+    dayStart.setHours(0, 0, 0, 0);
+    const startMs = dayStart.getTime();
+    return clusterResult.stays
+      .filter((s) => s.endTime >= startMs && s.startTime <= now)
+      .sort((a, b) => a.startTime - b.startTime)
+      .map((s) => ({
+        lat: s.centroid.latitude,
+        lon: s.centroid.longitude,
+        timestamp: s.startTime,
+      }));
+  }, [clusterResult]);
 
   // Tap on the [+] button next to a "Place N" row in PlacesDailyBreakdown.
   // Inspect proximity to known places and open either the merge-preview or
@@ -245,6 +276,7 @@ export function PlacesScreen({
         <StylizedMap
           currentLocation={snapshot?.location ?? null}
           knownPlaces={knownPlaces}
+          path={todaysPath}
         />
 
         <View style={styles.summaryCard}>


### PR DESCRIPTION
## Summary

- Implements **Option A** of issue #42 (Igor picked A via Telegram on 5/28).
- Adds an optional \`path\` prop to \`components/StylizedMap.tsx\` that overlays today's location path as a tinted polyline + breadcrumb dots on top of the existing stylized map. Known-place pins and the current-location pin still render on top.
- \`screens/PlacesScreen.tsx\` feeds the overlay with today's stay centroids in chronological order, derived from the already-computed \`clusterLocationsV2\` output (cluster result memoized once, reused for both the daily breakdown and the path).
- Stays \`View\`-only — no \`react-native-svg\` dependency added — to honor the spec's "stylized SVG, no Apple Maps key, no react-native-maps" constraint.
- Spec (\`docs/superpowers/specs/2026-05-25-tabbed-app-design.md\`) updated with the path-overlay behavior and two new Places acceptance criteria, per the repo's spec-first workflow.

## Files changed

- \`components/StylizedMap.tsx\` — new \`PathPoint\` export type, new \`path\` prop, bounding box extended to include path points, polyline segments rendered as rotated 2pt-high \`View\`s (\`transformOrigin: \"left center\"\` so rotation pivots on the segment start), small dots at each breadcrumb, \`onLayout\` to capture frame size needed for segment-length math.
- \`screens/PlacesScreen.tsx\` — \`clusterResult\` extracted into a memo so the path and the daily breakdown share one computation; \`todaysPath\` memo filters stays to today's local-time window and maps to \`{lat, lon, timestamp}\`; passed to \`<StylizedMap path={...} />\`.
- \`docs/superpowers/specs/2026-05-25-tabbed-app-design.md\` — Places tab description updated, two new acceptance criteria covering the 2+ stays overlay and 0–1 stays "no overlay" fallback.
- \`__tests__/StylizedMap.test.tsx\` — new: covers no-path / single-point / 3-point polyline / non-finite filter / empty state.

## Verification

- \`npx tsc --noEmit\` — clean.
- \`npx jest\` — 486/486 pass (was 481; 5 new \`StylizedMap.test.tsx\` cases).
- **iOS simulator testing is NOT possible from this Linux dev box** — \`just build\` / \`just deploy\` need Xcode + a Mac. Igor will need to verify on-device that the polyline renders inside the map frame, segments connect smoothly across the bounding box (especially after the projection bbox is now driven by both pins AND path points), and pins still sit on top.

## Things to eyeball on-device

- 2+ stays today: thin tinted line connects them in chronological order, with small dots at each breadcrumb. Current-location pin and known-place pins still on top.
- 0 or 1 stays today: map renders identically to pre-PR (no overlay).
- The bbox now includes path points, so if today's path wandered far from any known place, the map may zoom out more than it did before. Looks fine in test data — flag if it feels too zoomed out for a typical day.

## Related — Option C (separate issue, needs Mac)

Per #42, Option C is the **iOS home-screen map widget** (MapKit + WidgetKit, native Swift under \`ios/\`). Cannot be built or tested without a Mac, so it's been filed as a separate \`needs-mac\` issue so Igor can pick it up on his laptop. This PR ships the in-app Option A; Option C is additive, not a replacement.

## Test plan

- [ ] CI green (typecheck + jest).
- [ ] On-device: open Places tab on a day with 2+ recorded stays; verify polyline + dots render between known-place pins.
- [ ] On-device: open Places tab on a day with 0 or 1 stay; verify map renders pins-only (no overlay).
- [ ] Polyline stays inside the map frame across different routes (the bbox expansion should keep it inside the 10% pad).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map now displays your journey today: a connecting line with breadcrumb markers shows the path between visited places when you've been to multiple locations, appearing behind location pins.

* **Tests**
  * Added comprehensive test suite for the new path visualization, validating edge cases and backward compatibility.

* **Documentation**
  * Updated Places tab specification to reflect the new path display feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/context-grabber/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->