### PR TITLE
fix(map): regroup controls top-right + real copy glyph

### DIFF
--- a/components/StylizedMap.tsx
+++ b/components/StylizedMap.tsx
@@ -270,7 +270,7 @@ function MapSurface({
           hitSlop={8}
         >
           <Text style={styles.controlGlyph}>
-            {copyState === "copied" ? "✓" : "📋"}
+            {copyState === "copied" ? "✓" : "⧉"}
           </Text>
         </TouchableOpacity>
       )}
@@ -392,18 +392,19 @@ const styles = StyleSheet.create({
   },
 });
 
-// Control positions differ between embedded (compact, bottom-right stack) and
-// fullscreen (close at top clearing the notch, actions above the home bar).
+// All three controls stack at the top-right, out of the way of the map
+// content. Fullscreen on top, then find-me, then copy. The fullscreen
+// variant starts lower to clear the notch.
 const embeddedPositions = StyleSheet.create({
   fullscreen: { top: 8, right: 8 },
-  findMe: { bottom: 48, right: 8 },
-  copy: { bottom: 8, right: 8 },
+  findMe: { top: 48, right: 8 },
+  copy: { top: 88, right: 8 },
 });
 
 const fsPositions = StyleSheet.create({
   fullscreen: { top: 54, right: 16 },
-  findMe: { bottom: 96, right: 16 },
-  copy: { bottom: 48, right: 16 },
+  findMe: { top: 94, right: 16 },
+  copy: { top: 134, right: 16 },
 });
 
 const pinStyles = StyleSheet.create({


### PR DESCRIPTION
Polish follow-up to the map controls (#50/#51), from device feedback.

## Problems
- The new find-me button was stacked **directly on top of** the copy button at the bottom-right, turning copy into one of three look-alike dark pills — "where did the copy button go?"
- The copy button used 📋, which reads as **paste/clipboard**, not copy.

## Fixes
- **Regroup all three controls top-right**, stacked: fullscreen (⤢) → find-me (◎) → copy. Map content (path/pins) stays clear; copy is no longer buried next to find-me.
- **Copy glyph 📋 → ⧉** (two overlapping squares — the standard copy icon). No icon library added; stays consistent with the app's text-glyph convention.

## Testing
- 9 StylizedMap tests pass, `tsc` clean. Pure layout/glyph change — testIDs and behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)