### PR TITLE
feat(composer): inline mic + continuous record on Save & add another

### DIFF
--- a/__tests__/VoiceRecorder.test.tsx
+++ b/__tests__/VoiceRecorder.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { VoiceRecorder } from "../components/VoiceRecorder";
+
+// expo-audio is mocked in jest.setup.js with isRecording: false, so the
+// recorder renders in its idle state.
+describe("VoiceRecorder", () => {
+  it("renders a compact mic toggle when compact", () => {
+    const result = render(
+      <VoiceRecorder compact onRecorded={() => {}} />,
+    );
+    const btn = result.getByTestId("voice-record-toggle");
+    expect(btn).toBeTruthy();
+    expect(result.getByText("🎤")).toBeTruthy();
+  });
+
+  it("renders the full-width Record pill by default", () => {
+    const result = render(<VoiceRecorder onRecorded={() => {}} />);
+    expect(result.getByTestId("voice-record-toggle")).toBeTruthy();
+    expect(result.getByText("●  Record")).toBeTruthy();
+  });
+});

--- a/components/AffirmationCard.tsx
+++ b/components/AffirmationCard.tsx
@@ -71,44 +71,49 @@ export function AffirmationCard({ visible, onClose, db, initialRoleIds }: Props)
       errorExtra={{ affirmation: affirmation.title, ctx: context }}
       roleTestIDPrefix="affirm-role"
     >
-      <TouchableOpacity
-        onPress={() => setPicker(!picker)}
-        style={styles.affirmationBlock}
-      >
-        <Text style={styles.affirmationTitle}>{affirmation.title}</Text>
-        <Text style={styles.affirmationSubtitle}>{affirmation.subtitle}</Text>
-        <Text style={styles.swapHint}>tap to choose a different one</Text>
-      </TouchableOpacity>
+      {({ recorder }) => (
+        <>
+          <TouchableOpacity
+            onPress={() => setPicker(!picker)}
+            style={styles.affirmationBlock}
+          >
+            <Text style={styles.affirmationTitle}>{affirmation.title}</Text>
+            <Text style={styles.affirmationSubtitle}>{affirmation.subtitle}</Text>
+            <Text style={styles.swapHint}>tap to choose a different one</Text>
+          </TouchableOpacity>
 
-      {picker && (
-        <View style={styles.pickerBox}>
-          {AFFIRMATIONS.map((a, i) => (
-            <TouchableOpacity
-              key={a.title}
-              onPress={() => selectAffirmation(i)}
-              style={[styles.pickerRow, i === index && styles.pickerRowActive]}
-            >
-              <Text style={styles.pickerTitle}>{a.title}</Text>
-              <Text style={styles.pickerSubtitle}>{a.subtitle}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+          {picker && (
+            <View style={styles.pickerBox}>
+              {AFFIRMATIONS.map((a, i) => (
+                <TouchableOpacity
+                  key={a.title}
+                  onPress={() => selectAffirmation(i)}
+                  style={[styles.pickerRow, i === index && styles.pickerRowActive]}
+                >
+                  <Text style={styles.pickerTitle}>{a.title}</Text>
+                  <Text style={styles.pickerSubtitle}>{a.subtitle}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
+
+          <View style={styles.contextRow}>
+            <ContextButton
+              active={context === "opportunity"}
+              label="🎯 Opportunity"
+              onPress={() => setContext("opportunity")}
+            />
+            <ContextButton
+              active={context === "didit"}
+              label="✓ Did It"
+              onPress={() => setContext("didit")}
+            />
+            {recorder}
+          </View>
+
+          <Text style={styles.prompt}>{PROMPTS[context]}</Text>
+        </>
       )}
-
-      <View style={styles.contextRow}>
-        <ContextButton
-          active={context === "opportunity"}
-          label="🎯 Opportunity"
-          onPress={() => setContext("opportunity")}
-        />
-        <ContextButton
-          active={context === "didit"}
-          label="✓ Did It"
-          onPress={() => setContext("didit")}
-        />
-      </View>
-
-      <Text style={styles.prompt}>{PROMPTS[context]}</Text>
     </EntryComposer>
   );
 }
@@ -173,6 +178,7 @@ const styles = {
   pickerSubtitle: { color: "#999", fontSize: 12, marginTop: 2 },
   contextRow: {
     flexDirection: "row" as const,
+    alignItems: "center" as const,
     gap: 8,
     marginTop: 18,
   },

--- a/components/EntryComposer.tsx
+++ b/components/EntryComposer.tsx
@@ -26,6 +26,12 @@ import { RolePickerChips } from "./RolePickerChips";
 
 export type EntryTally = { opportunity: number; didit: number; grateful: number };
 
+/** Composer-owned elements a card can place within its own layout. */
+export type ComposerSlots = {
+  /** The voice-record control (compact mic when a card hosts it inline). */
+  recorder: React.ReactNode;
+};
+
 type Props = {
   visible: boolean;
   onClose: () => void;
@@ -36,8 +42,14 @@ type Props = {
   placeholder: string;
   /** Header right-side tally text, given today's counts. */
   renderTally: (t: EntryTally) => string;
-  /** Card-specific content rendered above the text field. */
-  children?: React.ReactNode;
+  /**
+   * Card-specific content rendered above the text field. Pass a render
+   * function to place composer-owned controls (e.g. the mic) inside the
+   * card's own layout — when a function is given, the composer does NOT
+   * render the recorder itself; the card decides where `slots.recorder`
+   * goes. A plain node keeps the default full-width recorder at the bottom.
+   */
+  children?: React.ReactNode | ((slots: ComposerSlots) => React.ReactNode);
   /** Build the JournalEntry to persist from the composed text/voice. */
   buildEntry: (args: {
     id: string;
@@ -120,6 +132,9 @@ export function EntryComposer({
     let voice = pendingVoice;
     const flushed = await recorderRef.current?.flush();
     if (flushed) voice = flushed;
+    // Were we actively recording at save time? Used below to continue the
+    // recording streak across "Save & add another".
+    const wasRecording = flushed != null;
 
     const text = textRef.current.trim();
     if (!text && !voice) {
@@ -180,6 +195,10 @@ export function EntryComposer({
       if (stayOpen) {
         setSavedHint("Saved · add another");
         setTimeout(() => setSavedHint(null), 1500);
+        // Continue the streak: if we were recording when Save & add another
+        // was tapped, start a fresh recording for the new blank entry so the
+        // user can keep dictating without re-tapping the mic.
+        if (wasRecording) void recorderRef.current?.start();
       } else {
         onClose();
       }
@@ -189,6 +208,19 @@ export function EntryComposer({
       setSaving(false);
     }
   }
+
+  // When children is a render function, the card places the recorder inline
+  // (compact mic in its own row); otherwise the composer renders it full-width.
+  const inline = typeof children === "function";
+  const recorderEl = (
+    <VoiceRecorder
+      ref={recorderRef}
+      compact={inline}
+      onRecorded={(v) => setPendingVoice(v)}
+      onError={(m) => setErrorMsg(m)}
+      disabled={saving}
+    />
+  );
 
   return (
     <Modal
@@ -212,7 +244,11 @@ export function EntryComposer({
           keyboardShouldPersistTaps="handled"
           automaticallyAdjustKeyboardInsets={Platform.OS === "ios"}
         >
-          {children}
+          {inline
+            ? (children as (slots: ComposerSlots) => React.ReactNode)({
+                recorder: recorderEl,
+              })
+            : children}
 
           <TextInput
             ref={inputRef}
@@ -240,24 +276,23 @@ export function EntryComposer({
             testIDPrefix={roleTestIDPrefix}
           />
 
-          <View style={{ marginTop: 16, alignItems: "center" }}>
-            <VoiceRecorder
-              ref={recorderRef}
-              onRecorded={(v) => setPendingVoice(v)}
-              onError={(m) => setErrorMsg(m)}
-              disabled={saving}
-            />
-            {pendingVoice && (
-              <View style={styles.voiceReady}>
-                <Text style={styles.voiceReadyText}>
-                  ✓ voice ready · {Math.round(pendingVoice.durationMs / 1000)}s
-                </Text>
-                <TouchableOpacity onPress={() => setPendingVoice(null)}>
-                  <Text style={styles.voiceClear}>discard</Text>
-                </TouchableOpacity>
-              </View>
-            )}
-          </View>
+          {/* Full-width recorder only when the card didn't place it inline. */}
+          {!inline && (
+            <View style={{ marginTop: 16, alignItems: "center" }}>
+              {recorderEl}
+            </View>
+          )}
+
+          {pendingVoice && (
+            <View style={styles.voiceReady}>
+              <Text style={styles.voiceReadyText}>
+                ✓ voice ready · {Math.round(pendingVoice.durationMs / 1000)}s
+              </Text>
+              <TouchableOpacity onPress={() => setPendingVoice(null)}>
+                <Text style={styles.voiceClear}>discard</Text>
+              </TouchableOpacity>
+            </View>
+          )}
 
           {errorMsg && (
             <CopyableError

--- a/components/VoiceRecorder.tsx
+++ b/components/VoiceRecorder.tsx
@@ -64,6 +64,10 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
   const [permissionAsked, setPermissionAsked] = useState(false);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const startTimeRef = useRef<number | null>(null);
+  // Synchronous recording flag. `state.isRecording` is polled every 250ms,
+  // so it lags real start/stop — a flush()→start() sequence within one tick
+  // would read a stale value. The imperative handle uses this ref instead.
+  const isRecordingRef = useRef(false);
 
   useEffect(() => {
     if (autoStart && !permissionAsked && !state.isRecording) {
@@ -75,13 +79,14 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
   // Recreated each render so it always closes over the latest recording
   // state + stop(); Save calls this to finalize an in-progress clip.
   useImperativeHandle(ref, () => ({
-    flush: async () => (state.isRecording ? await stop() : null),
+    flush: async () => (isRecordingRef.current ? await stop() : null),
     start: async () => {
-      if (!state.isRecording) await start();
+      await start();
     },
   }));
 
   async function start() {
+    if (isRecordingRef.current) return;
     try {
       if (!permissionAsked) {
         const perm = await requestRecordingPermissionsAsync();
@@ -109,6 +114,7 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
       // which manifests as "tap does nothing" with no error.
       await recorder.prepareToRecordAsync();
       recorder.record();
+      isRecordingRef.current = true;
       // Stash the target path on the recorder via closure — used in stop().
       (recorder as any).__targetPath = path;
     } catch (e: any) {
@@ -117,6 +123,7 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
   }
 
   async function stop(): Promise<RecordedVoice | null> {
+    isRecordingRef.current = false;
     try {
       await recorder.stop();
       const sourceUri = recorder.uri;

--- a/components/VoiceRecorder.tsx
+++ b/components/VoiceRecorder.tsx
@@ -30,6 +30,11 @@ export type VoiceRecorderHandle = {
    * in-progress recording instead of requiring a separate stop tap.
    */
   flush: () => Promise<RecordedVoice | null>;
+  /**
+   * Start a fresh recording. No-op if one is already in progress. Lets the
+   * parent continue a recording streak across "Save & add another".
+   */
+  start: () => Promise<void>;
 };
 
 type Props = {
@@ -38,6 +43,11 @@ type Props = {
   /** Auto-start recording when the recorder mounts (mobile-default UX). */
   autoStart?: boolean;
   disabled?: boolean;
+  /**
+   * Compact circular mic button (for placing in a button row) instead of
+   * the full-width pill. Same tap-to-toggle behavior; red while recording.
+   */
+  compact?: boolean;
 };
 
 /**
@@ -48,7 +58,7 @@ type Props = {
  * row + pairing it with the journal entry.
  */
 export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
-  function VoiceRecorder({ onRecorded, onError, autoStart, disabled }, ref) {
+  function VoiceRecorder({ onRecorded, onError, autoStart, disabled, compact }, ref) {
   const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
   const state = useAudioRecorderState(recorder, 250);
   const [permissionAsked, setPermissionAsked] = useState(false);
@@ -66,6 +76,9 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
   // state + stop(); Save calls this to finalize an in-progress clip.
   useImperativeHandle(ref, () => ({
     flush: async () => (state.isRecording ? await stop() : null),
+    start: async () => {
+      if (!state.isRecording) await start();
+    },
   }));
 
   async function start() {
@@ -140,11 +153,36 @@ export const VoiceRecorder = forwardRef<VoiceRecorderHandle, Props>(
       ? Math.floor((Date.now() - startTimeRef.current) / 1000)
       : 0;
 
+  if (compact) {
+    return (
+      <TouchableOpacity
+        onPress={recording ? stop : start}
+        disabled={disabled}
+        testID="voice-record-toggle"
+        accessibilityLabel={recording ? "Stop recording" : "Record voice"}
+        style={{
+          width: 52,
+          height: 52,
+          borderRadius: 26,
+          backgroundColor: recording ? "#d44" : "#1a1a1a",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text style={{ fontSize: recording ? 18 : 22 }}>
+          {recording ? "■" : "🎤"}
+        </Text>
+      </TouchableOpacity>
+    );
+  }
+
   return (
     <View style={{ alignItems: "center" }}>
       <TouchableOpacity
         onPress={recording ? stop : start}
         disabled={disabled}
+        testID="voice-record-toggle"
+        accessibilityLabel={recording ? "Stop recording" : "Record voice"}
         style={{
           backgroundColor: recording ? "#d44" : "#2a2a2a",
           paddingVertical: 14,

--- a/docs/superpowers/specs/2026-05-31-composer-inline-mic-design.md
+++ b/docs/superpowers/specs/2026-05-31-composer-inline-mic-design.md
@@ -1,0 +1,78 @@
+# Composer: inline mic + continuous record-on-add-another — design spec
+
+> **Status:** Drafted 2026-05-31. Two refinements to the shared entry composer behind the Affirmation and Grateful cards ([Affirmations & Gratitude Journal](2026-05-10-affirmations-journal-design.md)). Builds on the "Save while recording finalizes the clip" behavior already shipped (`c246fd7`).
+
+---
+
+## Summary
+
+1. **Continuous recording across "Save & add another".** If you're recording when you tap **Save & add another**, the clip is saved and a **fresh recording starts automatically** on the new blank entry — so you can rattle off several voice entries without re-tapping the mic each time.
+2. **Mic in line with Opportunity / Did It.** On the Affirmation card, the record control becomes a **compact mic button on the same row** as the Opportunity and Did-It buttons, instead of a separate full-width button lower down.
+
+## Problem
+
+- **Logging several voice entries in a row is clunky.** Today, "Save & add another" clears the card but leaves the mic idle — you have to tap Record again for each entry. When you're capturing a burst of reflections by voice, that re-tap breaks the flow.
+- **The record button is far from the action.** On the Affirmation card you pick a context (Opportunity / Did-It) and then your eye has to travel down past the text field to find Record. Putting the mic on the same row as the context buttons keeps the "choose how, then speak" controls together.
+
+## Goals
+
+- Tapping **Save & add another** *while recording* saves the current clip and immediately begins recording the next entry.
+- On the Affirmation card, **Record sits on the same row** as Opportunity / Did-It as a compact mic button.
+- The mic clearly shows recording state (it turns red while recording).
+- The shared composer stays shared — the Grateful card keeps working, and the mic can be placed by whichever card hosts it.
+
+## Non-goals
+
+- **No change to plain Save.** Plain **Save** still finalizes any in-progress clip, saves, and closes the card — it does not start a new recording (there's no new entry to record into).
+- **No change to the Grateful card's layout.** Grateful has no Opportunity/Did-It row; its record control stays where it is (full-width below the field). Only its Save-&-add-another gains the continuous-recording behavior, same as Affirmation.
+- **No change to what gets saved** — same audio file handling, same entry shape, same role tagging.
+- **No auto-start on first open.** Opening the card does not begin recording; the change is only about *continuing* a recording streak across Save & add another.
+
+---
+
+## User-visible behavior
+
+### Continuous record on "Save & add another"
+
+- While a recording is in progress, tapping **Save & add another**:
+  - finalizes and saves the current clip (today's behavior),
+  - clears the card for a new entry (today's behavior),
+  - **and immediately starts a new recording** so the mic is already live for the next entry.
+- The newly started recording shows the same live recording state (red mic) as a normally-started one.
+- If you tap **Save & add another** when **not** recording (e.g. a text entry, or a clip you already stopped), nothing new starts — behavior is unchanged.
+- Tapping plain **Save** while recording finalizes and saves the clip and **closes** the card — no new recording (unchanged).
+
+### Mic in line with Opportunity / Did It (Affirmation card)
+
+- The Opportunity and Did-It buttons remain the two primary buttons on their row; a **compact circular mic button sits to their right on the same row**.
+- The mic is **idle (neutral)** by default and **turns red while recording**. Tapping it starts/stops recording, exactly like the old Record button.
+- The separate full-width Record button no longer appears on the Affirmation card (its job moved to the inline mic).
+- After a recording is captured, the existing "voice ready · duration · discard" confirmation still appears so you can review or discard before saving.
+
+---
+
+## Acceptance criteria
+
+A non-technical reader should be able to walk these on the device:
+
+- **Streak by voice:** On the Affirmation card, tap the inline mic and speak ~3s, then tap **Save & add another**. The entry saves, the card clears, and the mic is **already recording** (red) for the next one. Speak again, tap **Save & add another** again — a second entry saves and recording continues. Tap **Save** to finish; the card closes.
+- **No phantom start:** Type a text entry (no recording) and tap **Save & add another**. The entry saves and the card clears, but the mic is **not** recording.
+- **Plain save closes:** Start recording, tap **Save** (not add-another). The clip saves and the card closes; the mic is off.
+- **Inline mic layout:** On the Affirmation card, Opportunity, Did-It, and the mic are on one row. The mic is neutral until tapped, then red while recording.
+- **Mic still captures:** Tap the inline mic, speak, tap it again to stop — the "voice ready · 0:0X" confirmation shows; saving attaches the clip.
+- **Grateful unaffected (layout):** The Grateful card looks the same as before (record control below the field), but its **Save & add another** also continues recording if one was in progress.
+
+## Decisions to confirm
+
+- **D1 — Mic glyph + recording affordance.** Compact mic shows a mic glyph when idle and a stop glyph (red) while recording. **Proposed default: 🎤 idle → red ■ while recording.** A live numeric timer is not shown on the compact mic itself (the post-stop "voice ready · duration" line already reports length); recording state is conveyed by the red color. Surface this so we agree the dropped inline timer is acceptable.
+- **D2 — Grateful card mic.** Leave Grateful's full-width record button as-is (proposed) vs. also make it compact. **Proposed default: leave as-is** — there's no context row for it to align with, so the full-width button stays the clearest affordance there.
+
+## Rationale
+
+- **Voice bursts are the point on a phone.** The journal's reason-for-being is fast capture; making a streak of voice entries a tap-speak-tap-speak rhythm (instead of tap-record-speak-stop-save-tap-record-…) removes the most repeated friction.
+- **Controls that go together, sit together.** "How am I logging this" (Opportunity / Did-It) and "capture it" (mic) are one decision cluster; co-locating them shortens the visual path and frees the vertical space the old full-width button used.
+
+## Cross-references
+
+- The composer, cards, voice recording, Save vs Save-&-add-another: [Affirmations & Gratitude Journal](2026-05-10-affirmations-journal-design.md).
+- "Save while recording finalizes the clip" (the behavior this extends): commit `c246fd7`.


### PR DESCRIPTION
Two refinements to the entry composer, from device feedback.

## What's in

### Continuous recording across "Save & add another"
- If you're **recording** when you tap **Save & add another**, the clip is saved and a **fresh recording starts automatically** on the new blank entry — so you can rattle off several voice entries without re-tapping the mic.
- Plain **Save** still finalizes + closes (no new recording). Tapping add-another on a text entry (not recording) does **not** start one.

### Mic in line with Opportunity / Did It
- On the Affirmation card, the record control is now a **compact circular mic** on the same row as Opportunity / Did-It (turns red while recording), instead of a separate full-width button below.
- The Grateful card is unchanged (no context row to align with; its add-another also continues recording).

## Implementation
- `VoiceRecorder` gains a `compact` mic variant + a `start()` imperative handle.
- `EntryComposer` accepts a **render-prop child** `(slots) => …` so a card can place the composer-owned mic in its own layout — exactly one recorder instance either way. (Also nudges toward the "movable components" direction.)
- **Review-caught bug fixed:** the restart guarded on `state.isRecording`, which is polled every 250ms and still reads `true` right after the flush's `stop()` — so the restart silently no-op'd. Now tracked with a synchronous `isRecordingRef`.

## Testing
- 512 tests pass (2 new: compact vs full-width recorder render). `tsc` clean.
- A code review of the diff found the polled-state restart bug (fixed) and otherwise confirmed exactly-one-recorder wiring, correct pendingVoice rendering, and Grateful unaffected.
- ⚠️ **Not device-verified** — the continuous-record streak and the inline mic layout/timer want a real run. (Note: the compact mic shows red state but no inline numeric timer; duration shows in the post-stop "voice ready" line.)

Spec: `docs/superpowers/specs/2026-05-31-composer-inline-mic-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)