### PR TITLE
fix(map): draw today's real GPS route instead of place-to-place lines

### DIFF
--- a/__tests__/location.test.ts
+++ b/__tests__/location.test.ts
@@ -1,4 +1,4 @@
-import { pruneThreshold } from "../lib/location";
+import { pruneThreshold, buildTodaysRoute } from "../lib/location";
 
 describe("pruneThreshold", () => {
   it("returns correct UTC cutoff for 30 day retention", () => {
@@ -36,5 +36,70 @@ describe("pruneThreshold", () => {
     const now = Date.UTC(2026, 2, 15, 0, 0, 0);
     const threshold = pruneThreshold(1, now);
     expect(now - threshold).toBe(86400000);
+  });
+});
+
+describe("buildTodaysRoute", () => {
+  // Local-time noon today, derived from a fixed base so tests are deterministic
+  // relative to the machine's TZ (buildTodaysRoute uses local midnight).
+  const noon = new Date(2026, 4, 31, 12, 0, 0).getTime();
+  const HOUR = 3600_000;
+  function pt(latOffset: number, msAgo: number) {
+    return { latitude: 47.6 + latOffset, longitude: -122.3, timestamp: noon - msAgo };
+  }
+
+  it("keeps only today's points, chronological, as {lat,lon,timestamp}", () => {
+    const route = buildTodaysRoute(
+      [pt(0.02, 1 * HOUR), pt(0.01, 2 * HOUR), pt(0.5, 30 * HOUR)], // last is yesterday
+      noon,
+    );
+    // Yesterday's point dropped; remaining two ordered oldest→newest.
+    expect(route.map((p) => p.timestamp)).toEqual([
+      noon - 2 * HOUR,
+      noon - 1 * HOUR,
+    ]);
+    expect(route[0].lat).toBeCloseTo(47.61, 6);
+    expect(route[1].lat).toBeCloseTo(47.62, 6);
+    expect(route[0].lon).toBe(-122.3);
+    expect(Object.keys(route[0]).sort()).toEqual(["lat", "lon", "timestamp"]);
+  });
+
+  it("drops non-finite coordinates", () => {
+    const route = buildTodaysRoute(
+      [
+        { latitude: NaN, longitude: -122.3, timestamp: noon - HOUR },
+        pt(0.01, 2 * HOUR),
+      ],
+      noon,
+    );
+    expect(route).toHaveLength(1);
+    expect(route[0].lat).toBe(47.61);
+  });
+
+  it("excludes future points (after now)", () => {
+    const route = buildTodaysRoute([pt(0.01, -HOUR), pt(0.02, HOUR)], noon);
+    expect(route).toHaveLength(1);
+    expect(route[0].timestamp).toBe(noon - HOUR);
+  });
+
+  it("thins to maxPoints, preserving first and last", () => {
+    const pts = Array.from({ length: 1000 }, (_, i) => ({
+      latitude: 47.6 + i * 0.0001,
+      longitude: -122.3,
+      timestamp: noon - (1000 - i) * 1000, // ascending, all within today
+    }));
+    const route = buildTodaysRoute(pts, noon, 100);
+    expect(route.length).toBeLessThanOrEqual(100);
+    expect(route[0].timestamp).toBe(pts[0].timestamp);
+    expect(route[route.length - 1].timestamp).toBe(pts[999].timestamp);
+  });
+
+  it("returns a single point unchanged (caller draws no line for <2)", () => {
+    const route = buildTodaysRoute([pt(0.01, HOUR)], noon);
+    expect(route).toHaveLength(1);
+  });
+
+  it("returns empty for no points", () => {
+    expect(buildTodaysRoute([], noon)).toEqual([]);
   });
 });

--- a/docs/superpowers/specs/2026-05-31-map-real-route-design.md
+++ b/docs/superpowers/specs/2026-05-31-map-real-route-design.md
@@ -1,0 +1,57 @@
+# Map: real GPS route instead of place-to-place lines — design spec
+
+> **Status:** Drafted 2026-05-31. Changes the today's-path overlay on `StylizedMap` (shipped in #44, per issue #42 "overlay today's path"). The Today and Places maps currently connect visited-place **centroids** with straight segments; this replaces that with the **actual GPS breadcrumb trail**.
+
+---
+
+## Summary
+
+Today's path on the map is drawn as straight lines between the centroids of the places you stayed at — so every segment is a literal "as-the-crow-flies" line *between* two locations. Replace it with the **real route**: the actual GPS breadcrumbs you logged today, in order, so the line follows where you actually went.
+
+## Problem
+
+The path overlay connects stay centroids (one point per place), in time order. The result is a star/triangle of straight lines hopping between your home, work, gym, etc. — lines that don't correspond to any real path and read as visual noise ("why is there a line cutting across the city?"). The information the line implies (a route) isn't the information it shows (place adjacency).
+
+## Goals
+
+- The map's path overlay follows the **actual recorded GPS track** for today, not straight place-to-place segments.
+- It stays **smooth and performant** even when today has many breadcrumbs (the trail is thinned so the line doesn't lag the map).
+- The place **pins**, the **"You" pin**, and the map controls are unchanged — only the line's shape changes.
+
+## Non-goals
+
+- **No road-snapping.** The line follows the raw GPS points; it does not call a routing/map-matching service to snap to roads. (Straight hops between sparse points are the GPS reality, not synthetic centroid links.)
+- **No change to clustering, place detection, or the daily breakdown.** Those still use stays/centroids; only the map line's source changes.
+- **No new data collection.** Uses the breadcrumbs already stored.
+- **No change to the find-me / fullscreen / copy controls or the pins.**
+
+---
+
+## User-visible behavior
+
+- The today's-path line on the **Today** map and the **Places** map follows the **actual GPS trail** logged today, in chronological order.
+- When today has a dense trail, the line is **thinned** (downsampled) to stay smooth — it still traces the real route, just with fewer vertices than every raw point.
+- If there are too few points to form a line (0 or 1 today), **no line** is drawn (same as today).
+- Place pins and the "You" pin render exactly as before; the map still frames to include the route.
+- Gaps where GPS was suppressed (e.g. a long stationary stretch, or travel with no fixes) appear as a straight segment between the last and next recorded point — that's the real recorded data, not a synthetic place link.
+
+## Acceptance criteria
+
+A non-technical reader should be able to walk these on the device:
+
+- **Follows the real track:** After a day with a walk/drive between two places, the map line **traces the route taken** (curves, turns) rather than a single straight segment between the two place pins.
+- **No cross-map star:** Visiting three places no longer draws a triangle of straight centroid-to-centroid lines.
+- **Stays smooth:** On a day with a long, dense trail, panning/zooming the map stays responsive (the line is thinned, not every raw point).
+- **Sparse day:** With only one recorded point today, no line is drawn.
+- **Pins unchanged:** Known-place pins and the "You" pin appear as before; the map frames to show the whole route.
+
+## Rationale
+
+- **Show the information you imply.** A line between dots reads as "this is the path." Making it the *actual* path removes the lie; the straight centroid links were technically a route the user never took.
+- **Thinning over precision.** A map widget doesn't need every breadcrumb to convey the route; thinning keeps it legible and fast while preserving the shape. Road-snapping would be prettier but adds a network dependency and a failure mode for marginal benefit — out of scope.
+
+## Cross-references
+
+- The map widget, pins, controls: `components/StylizedMap.tsx`; map controls spec [2026-05-31-map-controls-design.md](2026-05-31-map-controls-design.md).
+- Today's-path overlay origin: issue #42 / PR #44.
+- Clustering / stays (still used for pins + breakdown): [location clustering v2](2026-03-26-location-clustering-v2.md).

--- a/lib/location.ts
+++ b/lib/location.ts
@@ -15,3 +15,63 @@ export function pruneThreshold(retentionDays: number, now: number): number {
   const safeDays = Math.max(0, retentionDays);
   return now - safeDays * 86400000;
 }
+
+export type RouteInputPoint = {
+  latitude: number;
+  longitude: number;
+  timestamp: number;
+};
+
+export type RoutePathPoint = {
+  lat: number;
+  lon: number;
+  timestamp: number;
+};
+
+/**
+ * Build today's GPS route for the map overlay: the raw breadcrumbs logged
+ * since local midnight (up to `now`), in chronological order, thinned to at
+ * most `maxPoints` so the polyline stays smooth. The first and last points
+ * are always kept; non-finite coordinates are dropped. Pure — `now` drives
+ * the local-day window.
+ */
+export function buildTodaysRoute(
+  points: RouteInputPoint[],
+  now: number,
+  maxPoints = 400,
+): RoutePathPoint[] {
+  const dayStart = new Date(now);
+  dayStart.setHours(0, 0, 0, 0);
+  const startMs = dayStart.getTime();
+
+  const todays = points
+    .filter(
+      (p) =>
+        p.timestamp >= startMs &&
+        p.timestamp <= now &&
+        Number.isFinite(p.latitude) &&
+        Number.isFinite(p.longitude),
+    )
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  return thinPoints(todays, maxPoints).map((p) => ({
+    lat: p.latitude,
+    lon: p.longitude,
+    timestamp: p.timestamp,
+  }));
+}
+
+/**
+ * Evenly stride a list down to at most `maxPoints`, always keeping the first
+ * and last element so the route's endpoints are preserved.
+ */
+function thinPoints<T>(points: T[], maxPoints: number): T[] {
+  if (maxPoints < 2 || points.length <= maxPoints) return points;
+  const stride = (points.length - 1) / (maxPoints - 1);
+  const out: T[] = [];
+  for (let i = 0; i < maxPoints; i++) {
+    out.push(points[Math.round(i * stride)]);
+  }
+  // De-dup any repeats introduced by rounding near the tail.
+  return out.filter((p, i) => i === 0 || p !== out[i - 1]);
+}

--- a/screens/PlacesScreen.tsx
+++ b/screens/PlacesScreen.tsx
@@ -26,6 +26,7 @@ import {
   type LocationHistoryItem,
 } from "../lib/db";
 import { clusterLocationsV2 } from "../lib/clustering_v2";
+import { buildTodaysRoute } from "../lib/location";
 import { buildPlacesDailySummary } from "../lib/places_summary";
 import { haversineDistance } from "../lib/geo";
 
@@ -122,25 +123,13 @@ export function PlacesScreen({
     return assignPlaceColors(ids);
   }, [placesDailySummary]);
 
-  // Today's path overlay — stay centroids in chronological order, filtered
-  // to stays that overlap today's local-time window. Used by StylizedMap to
-  // draw a polyline between the day's visited known places. Per issue #42
-  // Option A: "Overlay today's location path (breadcrumbs / route)".
-  const todaysPath = useMemo(() => {
-    if (!clusterResult) return [];
-    const now = Date.now();
-    const dayStart = new Date(now);
-    dayStart.setHours(0, 0, 0, 0);
-    const startMs = dayStart.getTime();
-    return clusterResult.stays
-      .filter((s) => s.endTime >= startMs && s.startTime <= now)
-      .sort((a, b) => a.startTime - b.startTime)
-      .map((s) => ({
-        lat: s.centroid.latitude,
-        lon: s.centroid.longitude,
-        timestamp: s.startTime,
-      }));
-  }, [clusterResult]);
+  // Today's path overlay — the actual GPS breadcrumb trail for today (thinned),
+  // so the map line follows the real route rather than straight segments
+  // between visited-place centroids. Per the real-route design spec.
+  const todaysPath = useMemo(
+    () => buildTodaysRoute(rawPoints, Date.now()),
+    [rawPoints],
+  );
 
   // Tap on the [+] button next to a "Place N" row in PlacesDailyBreakdown.
   // Inspect proximity to known places and open either the merge-preview or

--- a/screens/TodayScreen.tsx
+++ b/screens/TodayScreen.tsx
@@ -14,6 +14,7 @@ import { StylizedMap } from "../components/StylizedMap";
 import type { ContextSnapshot } from "../lib/appTypes";
 import type { KnownPlace } from "../lib/places";
 import { clusterLocationsV2 } from "../lib/clustering_v2";
+import { buildTodaysRoute } from "../lib/location";
 import { buildPlacesDailySummary } from "../lib/places_summary";
 import { assignPlaceColors } from "../lib/places_colors";
 import type { LocationHistoryItem } from "../lib/db";
@@ -102,11 +103,9 @@ export function TodayScreen({
       .filter((s) => s.endTime >= startMs && s.startTime <= now)
       .sort((a, b) => a.startTime - b.startTime);
 
-    const path = todaysStays.map((s) => ({
-      lat: s.centroid.latitude,
-      lon: s.centroid.longitude,
-      timestamp: s.startTime,
-    }));
+    // The map line follows the actual GPS breadcrumb trail for today, not
+    // straight segments between stay centroids (see real-route design spec).
+    const path = buildTodaysRoute(rawPoints, now);
 
     const todaysPlaceIds = new Set(todaysStays.map((s) => s.placeId));
     const todaysKnownPlaces = knownPlaces.filter((p) =>


### PR DESCRIPTION
The map's "today's path" line connected visited-place **centroids** with straight segments — every line was an as-the-crow-flies hop *between* locations (a triangle across the city), not a real route. Per your call, it now follows the **actual GPS breadcrumb trail**.

## What changed
- New pure helper `buildTodaysRoute(points, now, maxPoints=400)` (`lib/location.ts`): today's raw breadcrumbs since local midnight, chronological, **thinned** to ≤400 points (endpoints preserved) so the polyline stays smooth.
- Both the **Today** and **Places** maps feed `StylizedMap` this trail instead of stay centroids. Clustering still drives the pins, colors, and daily breakdown — only the line's source changed.

## Behavior
- The line traces the route you actually took (curves, turns), not a straight place-to-place segment.
- Dense days are thinned so panning/zooming stays responsive.
- <2 points today → no line (unchanged). Pins + "You" pin unchanged; map still frames the whole route.
- GPS-suppressed gaps show as a straight segment between real recorded points (the actual data, not a synthetic place link).

## Testing
- 516 tests pass (6 new for `buildTodaysRoute`: today-window filter, chronological sort, non-finite drop, future-exclusion, thinning with endpoint preservation, empty/single). `tsc` clean.
- Code review of the diff: no findings (stride math, de-dup, local-midnight, scope, and the StylizedMap consumer all verified).
- ⚠️ **Not device-verified** — the real-route shape and thinning on a dense day want a real run.

Spec: `docs/superpowers/specs/2026-05-31-map-real-route-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)