### PR TITLE
fix(map): copy + find-me stay visible; 'waiting for GPS lock' hint instead of vanishing

### DIFF
--- a/__tests__/StylizedMap.test.tsx
+++ b/__tests__/StylizedMap.test.tsx
@@ -82,17 +82,35 @@ describe("StylizedMap", () => {
     expect(result.getByTestId("map-fullscreen")).toBeTruthy();
   });
 
-  it("hides the find-me control when there is no current location", () => {
-    // Places give a region so the map still renders, but with no "You"
-    // pin there is nothing to recenter on.
+  it("keeps find-me and copy visible without a current location (no You pin)", () => {
+    // Places give a region so the map still renders. The controls stay put
+    // so they don't vanish; tapping them shows a "waiting for a lock" hint.
     const result = render(
       <StylizedMap currentLocation={null} knownPlaces={baseProps.knownPlaces} />,
     );
     expect(result.getByTestId("stylized-map")).toBeTruthy();
     expect(result.queryByTestId("map-pin-current")).toBeNull();
-    expect(result.queryByTestId("map-find-me")).toBeNull();
-    // Fullscreen is still available even without a current location.
+    expect(result.getByTestId("map-find-me")).toBeTruthy();
+    expect(result.getByTestId("map-copy-coords")).toBeTruthy();
     expect(result.getByTestId("map-fullscreen")).toBeTruthy();
+  });
+
+  it("shows the waiting-for-lock hint when find-me is tapped with no location", () => {
+    const result = render(
+      <StylizedMap currentLocation={null} knownPlaces={baseProps.knownPlaces} />,
+    );
+    expect(result.queryByTestId("map-hint")).toBeNull();
+    fireEvent.press(result.getByTestId("map-find-me"));
+    expect(result.getByTestId("map-hint")).toBeTruthy();
+    expect(result.getByText(/Waiting for a live GPS lock/)).toBeTruthy();
+  });
+
+  it("shows the hint when copy is tapped with no location", () => {
+    const result = render(
+      <StylizedMap currentLocation={null} knownPlaces={baseProps.knownPlaces} />,
+    );
+    fireEvent.press(result.getByTestId("map-copy-coords"));
+    expect(result.getByTestId("map-hint")).toBeTruthy();
   });
 
   it("opens a fullscreen surface when the fullscreen control is tapped", () => {

--- a/components/StylizedMap.tsx
+++ b/components/StylizedMap.tsx
@@ -157,9 +157,22 @@ function MapSurface({
 }: SurfaceProps) {
   const mapRef = useRef<MapView>(null);
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+  // Transient hint shown when a location-dependent control is tapped before
+  // there's a live GPS fix (the controls stay visible so they don't vanish).
+  const [hint, setHint] = useState<string | null>(null);
+
+  const NO_LOCK = "Waiting for a live GPS lock…";
+
+  function showHint(msg: string) {
+    setHint(msg);
+    setTimeout(() => setHint(null), 1800);
+  }
 
   function handleFindMe() {
-    if (!currentLocation) return;
+    if (!currentLocation) {
+      showHint(NO_LOCK);
+      return;
+    }
     mapRef.current?.animateToRegion(
       {
         latitude: currentLocation.latitude,
@@ -172,7 +185,10 @@ function MapSurface({
   }
 
   async function handleCopyCoords() {
-    if (!currentLocation) return;
+    if (!currentLocation) {
+      showHint(NO_LOCK);
+      return;
+    }
     const text = `${currentLocation.latitude.toFixed(6)}, ${currentLocation.longitude.toFixed(6)}`;
     await Clipboard.setStringAsync(text);
     setCopyState("copied");
@@ -249,30 +265,34 @@ function MapSurface({
         <Text style={styles.controlGlyph}>{fullscreen ? "⤡" : "⤢"}</Text>
       </TouchableOpacity>
 
-      {currentLocation && (
-        <TouchableOpacity
-          onPress={handleFindMe}
-          style={[styles.control, pos.findMe]}
-          testID={`${idPrefix}find-me`}
-          accessibilityLabel="Recenter map on my location"
-          hitSlop={8}
-        >
-          <Text style={styles.controlGlyph}>◎</Text>
-        </TouchableOpacity>
-      )}
+      <TouchableOpacity
+        onPress={handleFindMe}
+        style={[styles.control, pos.findMe, !currentLocation && styles.controlIdle]}
+        testID={`${idPrefix}find-me`}
+        accessibilityLabel="Recenter map on my location"
+        hitSlop={8}
+      >
+        <Text style={styles.controlGlyph}>◎</Text>
+      </TouchableOpacity>
 
-      {currentLocation && (
-        <TouchableOpacity
-          onPress={handleCopyCoords}
-          style={[styles.control, pos.copy]}
-          testID={`${idPrefix}copy-coords`}
-          accessibilityLabel="Copy current coordinates"
-          hitSlop={8}
-        >
-          <Text style={styles.controlGlyph}>
-            {copyState === "copied" ? "✓" : "⧉"}
-          </Text>
-        </TouchableOpacity>
+      <TouchableOpacity
+        onPress={handleCopyCoords}
+        style={[styles.control, pos.copy, !currentLocation && styles.controlIdle]}
+        testID={`${idPrefix}copy-coords`}
+        accessibilityLabel="Copy current coordinates"
+        hitSlop={8}
+      >
+        <Text style={styles.controlGlyph}>
+          {copyState === "copied" ? "✓" : "⧉"}
+        </Text>
+      </TouchableOpacity>
+
+      {hint && (
+        <View style={styles.hintWrap} pointerEvents="none">
+          <View style={styles.hintBubble} testID={`${idPrefix}hint`}>
+            <Text style={styles.hintText}>{hint}</Text>
+          </View>
+        </View>
       )}
     </View>
   );
@@ -390,6 +410,24 @@ const styles = StyleSheet.create({
     color: "#fff",
     textAlign: "center",
   },
+  // Dimmed slightly when there's no live fix yet — still tappable (taps show
+  // the "waiting for a lock" hint) but visually signals it's not ready.
+  controlIdle: { opacity: 0.55 },
+  hintWrap: {
+    position: "absolute",
+    bottom: 10,
+    left: 0,
+    right: 0,
+    alignItems: "center",
+  },
+  hintBubble: {
+    maxWidth: 240,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 14,
+    backgroundColor: "rgba(20, 20, 30, 0.88)",
+  },
+  hintText: { color: "#fff", fontSize: 12, textAlign: "center" },
 });
 
 // All three controls stack at the top-right, out of the way of the map

--- a/docs/superpowers/specs/2026-05-31-map-controls-design.md
+++ b/docs/superpowers/specs/2026-05-31-map-controls-design.md
@@ -41,7 +41,8 @@ The embedded map is small and, once you pan/zoom around, there's no quick way ba
 - A **locate control** (standard locate/target icon) sits as an overlay on the map.
 - Tapping it **animates** the camera to center on the current location at a **street-level zoom** (closer than the default fit-to-content view), so "You" is centered and the immediate surroundings are legible.
 - The known-place pins, the "You" pin, and the today's-path polyline are unaffected — the control only moves the camera.
-- If there is no current location, the control is not shown (there's nothing to center on).
+- The control is **always visible** (so it never vanishes between fixes). If there's no current location yet, tapping it shows a brief **"Waiting for a live GPS lock…"** hint instead of moving the camera, and the control dims slightly to signal it's not ready. *(Amended 2026-05-31: previously hidden without a location; hiding made the buttons disappear whenever a grab missed a fix. We don't fall back to last-known — stale coordinates would mislead.)*
+- The **copy-coordinates** control behaves the same: always visible, and tapping it without a fix shows the same hint (there's nothing to copy until there's a location).
 
 ### Fullscreen
 
@@ -63,7 +64,7 @@ The embedded map is small and, once you pan/zoom around, there's no quick way ba
 A non-technical reader should be able to walk these on the device:
 
 - **Find me recenters:** On the Today screen, drag the map far away from your position and zoom out. Tap the locate button. The map animates back so the "You" pin is centered and zoomed to street level. The path and place pins are still drawn.
-- **Find me hidden without location:** With no current location (fresh install, no grab yet), the map's empty state shows and no locate button appears.
+- **No-lock hint:** With no current location (no fix yet), the locate and copy buttons are still visible (slightly dimmed). Tapping either shows a brief "Waiting for a live GPS lock…" hint and does nothing else. Once a fix arrives, both work normally.
 - **Fullscreen expands:** Tap the expand button. The map fills the screen, showing the same path and pins.
 - **Fullscreen find-me works:** While fullscreen, pan away, tap locate — it recenters within the fullscreen map.
 - **Collapse returns:** Tap the collapse/close control (or swipe down) — the map returns to its embedded size on the underlying screen, unchanged.


### PR DESCRIPTION
**Bug you hit:** the copy (⧉) and find-me/current-location (◎) buttons vanished from the map. Root cause: both were gated on `currentLocation`, which is `snapshot.location` — when a grab misses a GPS fix it overwrites the cached one with `null`, so the two buttons disappeared (fullscreen stayed because it doesn't need a location). Not from the recent PRs; it's how the original map controls were gated.

## Fix
- **Copy + find-me are now always visible** (slightly dimmed when there's no fix), so they never vanish.
- Tapping either **without a live fix** shows a transient **"Waiting for a live GPS lock…"** hint and does nothing else. Once a fix arrives, both work normally.
- **No last-known-location fallback** — per your call, stale coordinates would be weird/misleading; honest "no lock yet" is better.

## Testing
- 512 tests pass (3 new/updated: controls stay visible without a location; find-me and copy each show the hint on tap). `tsc` clean.
- ⚠️ **Not device-verified** — the hint bubble + dimmed state want a real look.

Spec amended in place: `docs/superpowers/specs/2026-05-31-map-controls-design.md` (the old "hidden without location" behavior is replaced + annotated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)